### PR TITLE
Rectangle selection

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -954,6 +954,7 @@ import { usezoomhome} from './composables/leaflet/useZoomHome';
 import { useImageOverlay } from "./composables/leaflet/useImageOverlay";
 import { useFieldOfRegard} from "./composables/leaflet/useFieldOfRegard";
 import { useLocationMarker } from "./composables/leaflet/useMarker";
+import { useRectangleSelection } from "./composables/leaflet/useRectangleSelection";
 const zoomScale = 1; 
 
 // const zoomScale = 0.5; // for matplibre-gl
@@ -1356,14 +1357,15 @@ const showingExtendedRange = computed(() => {
 });
 
 
-
-
 const onMapReady = (map) => {
   map.on('moveend', updateURL);
   map.on('zoomend', updateURL);
 };
 const showRoads = ref(true);
 const { map, createMap, setView } = useMap("map", initState.value, showRoads, onMapReady);
+const { active, selectionInfo } = useRectangleSelection(map, "red");
+
+watch(selectionInfo, (info) => console.log(info));
 
 const { 
   addFieldOfRegard,
@@ -1383,6 +1385,8 @@ onMounted(() => {
   window.addEventListener("hashchange", updateHash);
   showSplashScreen.value = false;
   createMap();
+
+  active.value = true;
 
   usezoomhome(map, homeState.value.loc, homeState.value.zoom, (_e: Event) => {
     sublocationRadio.value = null;

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -954,7 +954,6 @@ import { usezoomhome} from './composables/leaflet/useZoomHome';
 import { useImageOverlay } from "./composables/leaflet/useImageOverlay";
 import { useFieldOfRegard} from "./composables/leaflet/useFieldOfRegard";
 import { useLocationMarker } from "./composables/leaflet/useMarker";
-import { useRectangleSelection } from "./composables/leaflet/useRectangleSelection";
 const zoomScale = 1; 
 
 // const zoomScale = 0.5; // for matplibre-gl
@@ -1363,9 +1362,6 @@ const onMapReady = (map) => {
 };
 const showRoads = ref(true);
 const { map, createMap, setView } = useMap("map", initState.value, showRoads, onMapReady);
-const { active, selectionInfo } = useRectangleSelection(map, "red");
-
-watch(selectionInfo, (info) => console.log(info));
 
 const { 
   addFieldOfRegard,
@@ -1385,8 +1381,6 @@ onMounted(() => {
   window.addEventListener("hashchange", updateHash);
   showSplashScreen.value = false;
   createMap();
-
-  active.value = true;
 
   usezoomhome(map, homeState.value.loc, homeState.value.zoom, (_e: Event) => {
     sublocationRadio.value = null;

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -54,6 +54,7 @@ export function useRectangleSelection(
       map.value?.removeLayer(rect);
       rect = null;
     }
+    startCoords = null;
   }
 
   function onMousemove(event: LeafletMouseEvent) {

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -1,4 +1,4 @@
-import { onMounted, ref, watch, type Ref } from "vue";
+import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { type LatLng, LatLngBounds, type LeafletMouseEvent, Map, Rectangle } from "leaflet";
 
 export interface RectangleSelectionInfo {
@@ -92,6 +92,15 @@ export function useRectangleSelection(
   watch(map, (newMap: Map | null) => {
     if (newMap !== null) {
       updateListeners(newMap, active.value);
+    }
+  });
+
+  onUnmounted(() => {
+    // The map will probably be destroyed along with the component using this composable
+    // But if not, we should remove handlers
+    const lMap = map.value;
+    if (lMap !== null && active.value) {
+      updateListeners(lMap, false);
     }
   });
 

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -1,0 +1,83 @@
+import { ref, watch, type Ref } from "vue";
+import { type LatLng, LatLngBounds, type LeafletMouseEvent, Map, Rectangle } from "leaflet";
+
+export interface RectangleSelectionInfo {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+}
+
+export function useRectangleSelection(
+  map: Ref<Map | null>, 
+  interactColor: string = "yellow",
+) {
+  let rect: Rectangle | null = null;
+  let startCoords: LatLng | null = null;
+  const selectionInfo = ref<RectangleSelectionInfo | null>(null);
+  const active = ref(false);
+
+  function onMousedown(event: LeafletMouseEvent) {
+    startCoords = event.latlng;
+    rect = new Rectangle(new LatLngBounds(startCoords, startCoords));
+    rect.setStyle({
+      weight: 1,
+      fillOpacity: 0,
+      dashArray: [5, 5],
+      color: interactColor,
+    });
+    map.value?.addLayer(rect);
+  }
+
+  function onMouseup(event: LeafletMouseEvent) {
+    if (startCoords === null) {
+      return;
+    }
+
+    const eventCoords = event.latlng;
+    selectionInfo.value = {
+      xmin: startCoords.lng,
+      ymin: startCoords.lat,
+      xmax: eventCoords.lng,
+      ymax: eventCoords.lat,
+    };
+
+    if (rect) {
+      map.value?.removeLayer(rect);
+      rect = null;
+    }
+  }
+
+  function onMousemove(event: LeafletMouseEvent) {
+    if (startCoords === null || rect === null) {
+      return;
+    }
+    rect.setBounds(new LatLngBounds(startCoords, event.latlng));
+  }
+
+  watch(active, (nowActive: boolean) => {
+    const lMap = map.value;
+    if (lMap === null) {
+      return;
+    }
+    if (nowActive) {
+      lMap.dragging.disable();
+      lMap.scrollWheelZoom.disable();
+      lMap.addEventListener("mousedown", onMousedown);
+      lMap.addEventListener("mouseup", onMouseup);
+      lMap.addEventListener("mousemove", onMousemove);
+    } else {
+      lMap.dragging.enable();
+      lMap.scrollWheelZoom.enable();
+      lMap.removeEventListener("mousedown", onMousedown);
+      lMap.removeEventListener("mouseup", onMouseup);
+      lMap.removeEventListener("mousemove", onMousemove);
+    }
+  });
+
+  return {
+    selectionInfo,
+    active,
+  };
+
+}

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -1,4 +1,4 @@
-import { onMounted, ref, watch, type Ref } from "vue";
+import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { GeoJSONSource, LngLat, Map, MapMouseEvent } from "maplibre-gl";
 import { v4 } from "uuid";
 
@@ -165,6 +165,15 @@ export function useRectangleSelection(
   watch(map, (newMap: Map | null) => {
     if (newMap !== null) {
       updateListeners(newMap, active.value);
+    }
+  });
+
+  onUnmounted(() => {
+    // The map will probably be destroyed along with the component using this composable
+    // But if not, we should remove handlers
+    const mMap = map.value;
+    if (mMap !== null && active.value) {
+      updateListeners(mMap, false);
     }
   });
 

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -1,0 +1,76 @@
+import { onMounted, ref, watch, type Ref } from "vue";
+import { LngLat, Map, MapMouseEvent, Rect, Source } from "maplibre-gl";
+import { v4 } from "uuid";
+
+export interface RectangleSelectionInfo {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+}
+
+export function useRectangleSelection(
+  map: Ref<Map | null>,
+  interactColor: string = "yellow",
+  startActive: boolean = false,
+) {
+  let rectangleSource: Source | null = null;
+  let startCoords: LngLat | null = null;
+  const selectionInfo = ref<RectangleSelectionInfo | null>(null);
+  const active = ref(startActive);
+  const uuid = v4();
+
+  onMounted(() => {
+    const mMap = map.value;
+    if (active.value && mMap) {
+      updateListeners(mMap, active.value);
+    }
+  });
+
+  function onMousedown(event: MapMouseEvent) {
+    const mMap = map.value;
+    if (!mMap) {
+      return;
+    }
+
+    startCoords = event.lngLat;
+    const geoJSON: GeoJSON.GeoJSON = {
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        geometry: {
+          type: "Polygon",
+          coordinates: [[
+            [startCoords.lng, startCoords.lat],
+            [startCoords.lng, startCoords.lat],
+            [startCoords.lng, startCoords.lat],
+            [startCoords.lng, startCoords.lat],
+          ]],
+        },
+        properties: {},
+      }],
+    };
+
+    mMap.addSource(uuid, {
+      type: "geojson",
+      data: geoJSON,
+    });
+
+    const source = mMap.getSource(uuid);
+    if (!source) {
+      return;
+    }
+
+    rectangleSource = source;
+
+    mMap.addLayer({
+      id: uuid,
+      type: "line",
+      source: uuid,
+      paint: {
+        "line-color": interactColor,
+        "line-pattern":
+      }
+    });
+  }
+}


### PR DESCRIPTION
This PR adds composables for allowing using rectangle selection in both Leaflet and MapLibre. Each composable returns two items:

* An `active` ref. When set to true the selection mode is enabled, when false it is disabled. The idea is that some UI element (e.g. a button) could then control this state.
* A ref containing the selection info, which is updated when the selection ends. Currently this is an object with the form
```typescript
export interface RectangleSelectionInfo {
  xmin: number;
  xmax: number;
  ymin: number;
  ymax: number;
}
```

This is a plain object for now for flexibility, but if we're always going to use a GeoJSON object then we could just have the value be that instead.

I didn't update the UI to use this for now, but you can test it by replacing what's in `TempoLite.vue` starting at line 1366 with the following (this will make selection stay active and log the selection info in the console window).

```typescript
const { active, selectionInfo } = useRectangleSelection(map, "red");

watch(selectionInfo, (info) => console.log(info));

const { 
  addFieldOfRegard,
  showFieldOfRegard,
  updateFieldOfRegard 
} = useFieldOfRegard(singleDateSelected, map);

const {
  setMarker,
  removeMarker,
  locationMarker
} = useLocationMarker(map,  showLocationMarker.value);



onMounted(() => {
  window.addEventListener("hashchange", updateHash);
  showSplashScreen.value = false;
  createMap();

  active.value = true;
```