### PR TITLE
Add missing packages from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "@wwtelescope/engine-pinia": "^0.9.0",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "esri-leaflet": "^3.0.17",
     "leaflet": "^1.9.4",
     "leaflet.zoomhome": "^1.0.0",
+    "mapbox-gl-esri-sources": "^0.0.7",
     "maplibre-gl": "^5.5.0",
     "uuid": "^11.1.0",
     "vue": "^3.4.15",
@@ -20,6 +22,7 @@
     "webpack-plugin-vuetify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/esri-leaflet": "^3.0.3",
     "@types/leaflet": "^1.9.11",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,18 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@terraformer/arcgis@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/arcgis/-/arcgis-2.1.2.tgz#9e05cc5e0ddc400e532f6ccb1d91bdf420e4a756"
+  integrity sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==
+  dependencies:
+    "@terraformer/common" "^2.1.2"
+
+"@terraformer/common@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/common/-/common-2.1.2.tgz#7bf83f81f1c3a99069c714c044004f9707f00c97"
+  integrity sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -525,6 +537,13 @@
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
+
+"@types/esri-leaflet@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/esri-leaflet/-/esri-leaflet-3.0.3.tgz#14c67eaac6e5dc47a4e7b1d74f97c988580d587b"
+  integrity sha512-trg5D2xqYITp3X6WAGSZ1cRWZz3qkbMkc+6zaiPNOE+klauKEVWfBDExcS96abbXxeUz2DWJ6iZ/A5nkeUVk4g==
+  dependencies:
+    "@types/leaflet" "*"
 
 "@types/estree@*", "@types/estree@^1.0.8":
   version "1.0.8"
@@ -604,7 +623,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/leaflet@^1.9.11":
+"@types/leaflet@*", "@types/leaflet@^1.9.11":
   version "1.9.20"
   resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.9.20.tgz#a7feef4b0a4b36335dfc98456e76c0a86ab8462c"
   integrity sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==
@@ -2516,6 +2535,14 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
+esri-leaflet@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-3.0.17.tgz#b415a65a17e00fa91266efe29fc3386a8d0dd530"
+  integrity sha512-YBJ0n6qmO6rL+GAfCOBngmClvrZILDerGhK92ibcA47QTE6VVzkshFpe6KcSX/RdM6rS1cROld6fHNNhmTAL2w==
+  dependencies:
+    "@terraformer/arcgis" "^2.1.0"
+    tiny-binary-search "^1.0.3"
+
 estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
@@ -3690,6 +3717,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+mapbox-gl-esri-sources@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-esri-sources/-/mapbox-gl-esri-sources-0.0.7.tgz#8c95e11e548219044bf9075c336d730dbaf38e1f"
+  integrity sha512-fGicRrkoduXvuNSmZH9TG9emxSMaPGZYWYQo5wjc3mjejKThOcHLdkXONnqVXTu7Uyih1FGiij6/e2zqRDIdiQ==
 
 maplibre-gl@^5.5.0:
   version "5.6.1"
@@ -5386,6 +5418,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
+  integrity sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA==
 
 tinyqueue@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I think this was only working because we weren't actually building with esri yet. This was originally added here: https://github.com/cosmicds/tempo-lite/pull/126/commits/8262957a12eacad37218ac753d5e63dcb7adb6e9