### PR TITLE
Esri-getSamples

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "@wwtelescope/engine-pinia": "^0.9.0",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "esri-leaflet": "^3.0.17",
     "leaflet": "^1.9.4",
     "leaflet.zoomhome": "^1.0.0",
+    "mapbox-gl-esri-sources": "^0.0.7",
     "maplibre-gl": "^5.5.0",
     "uuid": "^11.1.0",
     "vue": "^3.4.15",
@@ -20,6 +22,7 @@
     "webpack-plugin-vuetify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/esri-leaflet": "^3.0.3",
     "@types/leaflet": "^1.9.11",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",

--- a/src/esri/geometry.ts
+++ b/src/esri/geometry.ts
@@ -1,0 +1,37 @@
+export type EsriGeometryType = 'esriGeometryPoint' | 'esriGeometryMultipoint' | 'esriGeometryPolyline' | 'esriGeometryPolygon' | 'esriGeometryEnvelope';
+
+export type RectBounds = {
+  xmin: number;
+  ymin: number;
+  xmax: number;
+  ymax: number;
+};
+
+export type PointBounds = {
+  x: number;
+  y: number;
+};
+export function rectangleToGeometry(rect: RectBounds) {
+  const { xmin, ymin, xmax, ymax } = rect;
+  return {
+    rings: [[
+      [xmin, ymin],
+      [xmin, ymax],
+      [xmax, ymax],
+      [xmax, ymin],
+      [xmin, ymin]
+    ]],
+    spatialReference: { wkid: 4326 } // Assuming WGS 84
+    // spatialReference: { wkid: 3857 } // Web Mercator. idk if this really matters for points
+  };
+}
+
+export function pointToGeometry(point: PointBounds) {
+  const { x, y } = point;
+  return {
+    x: x,
+    y: y,
+    spatialReference: { wkid: 4326 } // Assuming WGS 84
+    // spatialReference: { wkid: 3857 } // Web Mercator. idk if this really matters for points
+  };
+}

--- a/src/esri/imageServer/esriGetSamples.ts
+++ b/src/esri/imageServer/esriGetSamples.ts
@@ -1,0 +1,229 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { rectangleToGeometry, pointToGeometry } from '../geometry';
+import type { RectBounds, PointBounds, EsriGeometryType } from '../geometry';
+import type { EsriGetSamplesReturn, EsriGetSamplesReturnError, EsriGetSamplesSample, Variables, EsriInterpolationMethod, CEsriTimeseries } from '../types';
+
+function safeParseNumber(value: string | null | undefined): number | null {
+  if (value === null || value === '' || value === undefined) return null;
+
+  const parsed = parseFloat(value); // parsing only fails if 1st digit is not a number :)
+  return isNaN(parsed) ? null : parsed; // Return null if parsing fails
+}
+
+
+
+export interface EsriGetSamplesParameters {
+  geometry: ReturnType<typeof rectangleToGeometry> | ReturnType<typeof pointToGeometry>;
+  geometryType: EsriGeometryType;
+  sampleDistance?: number;
+  sampleCount?: number;
+  mosaicRule?: string | Record<string, unknown>;
+  pixelSize?: number;
+  returnFirstValueOnly?: boolean;
+  interpolation: EsriInterpolationMethod;
+  outFields?: string | string[];
+  sliceID?: string | number;
+  time?: string | [number, number] | [Date, Date];
+  f: 'pjson'; // Format of the response
+}
+
+function stringifyEsriGetSamplesParameters(params: EsriGetSamplesParameters): URLSearchParams {
+  const {
+    geometry,
+    geometryType,
+    sampleDistance,
+    sampleCount,
+    mosaicRule,
+    pixelSize,
+    returnFirstValueOnly,
+    interpolation,
+    outFields,
+    sliceID,
+    time,
+  } = params;
+  
+  
+
+  const options: Record<string, string> = {
+    f: 'pjson',
+    geometry: JSON.stringify(geometry),
+    geometryType: geometryType,
+    interpolation: interpolation,
+  };
+
+  if (sampleDistance) options.sampleDistance = sampleDistance.toString();
+  if (sampleCount) options.sampleCount = sampleCount.toString();
+  if (mosaicRule) options.mosaicRule = JSON.stringify(mosaicRule);
+  if (pixelSize) options.pixelSize = pixelSize.toString();
+  if (returnFirstValueOnly !== undefined) options.returnFirstValueOnly = returnFirstValueOnly.toString();
+  if (outFields) options.outFields = Array.isArray(outFields) ? outFields.join(',') : outFields;
+  if (sliceID !== undefined) options.sliceID = sliceID.toString();
+  if (time) {
+    const timeStr = Array.isArray(time)
+      ? time.map((t) => (t instanceof Date ? t.getTime() : t)).join(',')
+      : time;
+    options.time = timeStr;
+  }
+
+  return new URLSearchParams(options);
+}
+
+
+const esriGetSamplesRequest = async (url: string, params: EsriGetSamplesParameters): Promise<EsriGetSamplesReturn | EsriGetSamplesReturnError> => {
+  const getSamplesUrl = `${url}/getSamples/?`;
+  const urlWithParams = getSamplesUrl + stringifyEsriGetSamplesParameters(params).toString();
+  
+  console.log(urlWithParams.replace('pjson', 'html'));
+
+  try {
+    const response = await fetch(urlWithParams);
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error in esriGetSamplesRequest:', error);
+    throw error;
+  }
+};
+
+export function esriGetSamples(
+  url: string,
+  variableName: Variables,
+  geometry: RectBounds | PointBounds,
+  start: number,
+  end: number,
+  sampleCount: number = 30,
+): Promise<CEsriTimeseries[]> {
+  // const getSamplesUrl = `${url}/getSamples/?`;
+
+  const esriGeometry =
+    Object.keys(geometry).includes('xmin') ?
+      rectangleToGeometry(geometry as RectBounds)
+      : pointToGeometry(geometry as PointBounds);
+
+  const geometryType: EsriGeometryType =
+    Object.keys(geometry).includes('xmin') ?
+      'esriGeometryPolygon'
+      : 'esriGeometryPoint';
+
+  // https://developers.arcgis.com/rest/services-reference/enterprise/get-samples/
+  const options: EsriGetSamplesParameters = {
+    f: 'pjson',
+    interpolation: 'RSP_NearestNeighbor',
+    returnFirstValueOnly: false,
+    geometry: esriGeometry,
+    geometryType: geometryType,
+    time: `${start},${end}`,
+    sampleCount: sampleCount,
+  };
+  
+
+  return esriGetSamplesRequest(url, options)
+    .then((data) => {
+      if ('error' in data) {
+        throw new Error(`Error fetching samples (${data.error.code}): ${data.error.message} ${data.error.details}`);
+      }
+      // want to get the location x, y, the time, the variableName (NO2_Troposphere)
+      return data.samples.map((sample: EsriGetSamplesSample) => {
+        return {
+          x: sample.location.x,
+          y: sample.location.y,
+          time: sample.attributes.StdTime,
+          date: new Date(sample.attributes.StdTime), // assuming StdTime is in seconds
+          variable: safeParseNumber(sample.attributes[variableName] ?? ''), // assuming NO2_Troposphere is the variable we want
+          value: safeParseNumber(sample.value),
+          locationId: sample.locationId,
+        };
+      });
+    })
+    .catch((error) => {
+      console.error('Error fetching samples:', error);
+      throw error;
+    });
+}
+
+export function test() {
+  console.log('test function called');
+  const url =
+    'https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer';
+  const oneDay = 24 * 60 * 60 * 1000; // 1 day in milliseconds
+
+  const test_geometry = { x: -110, y: 44 };
+  // test small rectangle around new york city
+  // const test_geometry = {
+  //   xmin: -110,
+  //   ymin: 40,
+  //   xmax: -100,
+  //   ymax: 45,
+  // } as RectBounds;
+  esriGetSamples(
+    url,
+    'NO2_Troposphere',
+    test_geometry,
+    Date.now() - 3 * oneDay,
+    Date.now() - 2 * oneDay,
+    30,
+  )
+    .then((samples) => {
+      const grouped = groupSamplesByTime(samples);
+      const aggregated = aggregate(grouped, (samples) =>
+        nullMean(samples.map((sample) => sample.value)),
+      );
+      console.log('Aggregated Samples:', aggregated);
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+}
+
+export function groupSamplesByTime(
+  samples: CEsriTimeseries[],
+): Map<number, CEsriTimeseries[]> {
+  const groupd: Map<number, CEsriTimeseries[]> = new Map();
+
+  samples.forEach((sample) => {
+    if (!groupd.has(sample.time)) {
+      groupd.set(sample.time, []);
+    }
+    groupd.get(sample.time)?.push(sample);
+  });
+
+  return groupd;
+}
+
+function nullMean(samples: (number | null)[]): number | null {
+  const validSamples = samples.filter((sample) => sample !== null);
+  if (validSamples.length === 0) return null;
+  const sum = validSamples.reduce((acc, val) => acc + (val ?? 0), 0);
+  return sum / validSamples.length;
+}
+
+type AggValue = {
+  value: number | null;
+  date: Date;
+};
+export function aggregate(
+  grouped: Map<number, CEsriTimeseries[]>,
+  aggFunction: (samples: CEsriTimeseries[]) => number | null,
+) {
+  const aggregated: Record<number, AggValue> = {};
+  grouped.forEach((samples, time) => {
+    aggregated[time] = {value: aggFunction(samples), date: new Date(time)};
+  });
+  return aggregated;
+}
+
+
+// now write a function that takes a url and returns the aggregated values for a given variable, geometry, start and end time
+export async function getAggregatedSamples(
+  url: string,
+  variableName: Variables,
+  geometry: RectBounds | PointBounds,
+  start: number,
+  end: number,
+  sampleCount: number = 30,
+): Promise<Record<number, AggValue>> {
+  const samples = await esriGetSamples(url, variableName, geometry, start, end, sampleCount);
+  const grouped = groupSamplesByTime(samples);
+  return aggregate(grouped, (samples) => nullMean(samples.map((sample) => sample.value)));
+}

--- a/src/esri/types.ts
+++ b/src/esri/types.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface EsriGetSamplesReturn {
+  samples: EsriGetSamplesSample[];
+}
+
+export interface EsriGetSamplesSample {
+  location: Location;
+  locationId: number;
+  value: string;
+  resolution: number;
+  attributes: Attributes;
+}
+
+export interface EsriGetSamplesReturnError {
+  error: Error;
+}
+
+
+export interface Attributes {
+  NO2_Troposphere?: string;
+  HCHO?: string;
+  Ozone_Column_Amount?: string;
+  StdTime: number;
+  StdTime_Max: number;
+  Variables: Variables;
+  Dimensions: Dimensions;
+}
+
+export type Dimensions = "StdTime";
+
+export type Variables = "NO2_Troposphere" | "HCHO" | "Ozone_Column_Amount";
+
+
+export interface Location {
+  x: number;
+  y: number;
+  spatialReference: SpatialReference;
+}
+
+export interface SpatialReference {
+  wkid: number;
+  latestWkid: number;
+}
+
+
+export interface CEsriTimeseries {
+  x: number;
+  y: number;
+  time: number;
+  date: Date; 
+  variable: number | null;
+  value: number | null;
+  locationId: number;
+}
+
+
+export interface Error {
+  code:         number;
+  extendedCode: number;
+  message:      string;
+  details:      string[];
+}
+
+
+export type EsriInterpolationMethod = "RSP_BilinearInterpolation" | "RSP_CubicConvolution" | "RSP_Majority" | "RSP_NearestNeighbor";

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,18 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@terraformer/arcgis@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/arcgis/-/arcgis-2.1.2.tgz#9e05cc5e0ddc400e532f6ccb1d91bdf420e4a756"
+  integrity sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==
+  dependencies:
+    "@terraformer/common" "^2.1.2"
+
+"@terraformer/common@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/common/-/common-2.1.2.tgz#7bf83f81f1c3a99069c714c044004f9707f00c97"
+  integrity sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -525,6 +537,13 @@
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
+
+"@types/esri-leaflet@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/esri-leaflet/-/esri-leaflet-3.0.3.tgz#14c67eaac6e5dc47a4e7b1d74f97c988580d587b"
+  integrity sha512-trg5D2xqYITp3X6WAGSZ1cRWZz3qkbMkc+6zaiPNOE+klauKEVWfBDExcS96abbXxeUz2DWJ6iZ/A5nkeUVk4g==
+  dependencies:
+    "@types/leaflet" "*"
 
 "@types/estree@*", "@types/estree@^1.0.8":
   version "1.0.8"
@@ -604,7 +623,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/leaflet@^1.9.11":
+"@types/leaflet@*", "@types/leaflet@^1.9.11":
   version "1.9.20"
   resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.9.20.tgz#a7feef4b0a4b36335dfc98456e76c0a86ab8462c"
   integrity sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==
@@ -2516,6 +2535,14 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
+esri-leaflet@^3.0.17:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-3.0.17.tgz#b415a65a17e00fa91266efe29fc3386a8d0dd530"
+  integrity sha512-YBJ0n6qmO6rL+GAfCOBngmClvrZILDerGhK92ibcA47QTE6VVzkshFpe6KcSX/RdM6rS1cROld6fHNNhmTAL2w==
+  dependencies:
+    "@terraformer/arcgis" "^2.1.0"
+    tiny-binary-search "^1.0.3"
+
 estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
@@ -3690,6 +3717,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+mapbox-gl-esri-sources@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-esri-sources/-/mapbox-gl-esri-sources-0.0.7.tgz#8c95e11e548219044bf9075c336d730dbaf38e1f"
+  integrity sha512-fGicRrkoduXvuNSmZH9TG9emxSMaPGZYWYQo5wjc3mjejKThOcHLdkXONnqVXTu7Uyih1FGiij6/e2zqRDIdiQ==
 
 maplibre-gl@^5.5.0:
   version "5.6.1"
@@ -5386,6 +5418,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
+  integrity sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA==
 
 tinyqueue@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds routines for getting samples from the Esri ImageServer getSamples endpoint, extracting and processing the json object it returns, and then aggregating the data.

This can take a long time for large areas. Though in investigating this, I am not sure if the ImageSever is as actually taking every point within the area, or is rather just taking some sample of points within the area.

This has a test funciton which runs and prints the output to the console. It takes in two formats for coordinates
```ts
export type RectBounds = {
  xmin: number;
  ymin: number;
  xmax: number;
  ymax: number;
};

export type PointBounds = {
  x: number;
  y: number;
};
```


This can be implemented in `TempoLite.vue` with 

```ts
// eslint-disable-next-line @typescript-eslint/no-unused-vars
import {  test, getAggregatedSamples} from "./esri/imageServer/esriGetSamples";

test(); // a single point test


const loadingSamples = ref('false');

loadingSamples.value = 'loading';
getAggregatedSamples(
  'https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN/ImageServer',
  "NO2_Troposphere",
  {x: -98.789, y: 40.044}, // home location
  new Date('2025-07-19T00:00:00Z').getTime(), // Setting the date because the server is a day or two behind
  new Date('2025-07-20T00:00:00Z').getTime()).then((samples) => {
  console.log("Samples:", samples);
  loadingSamples.value = 'finished';
}).catch((error) => {
  console.error("Error fetching samples:", error);
  loadingSamples.value = 'error';
});
```