### PR TITLE
Allow making multiple selections

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1537,11 +1537,13 @@ const selectionOptions = computed<SelectionOption[]>(() => ([null] as SelectionO
 let selectionCount = 0;
 const samplesGraph = ref(false);
 const haveSamples = computed(() => selections.value.some(s => s.samples));
+
+// I stole this from here: https://sashamaps.net/docs/resources/20-colors/
 const COLORS = [
-  "#ff0000",
-  "#00ff00",
-  "#0000ff",
-  "#ffff00",
+  '#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231', '#911eb4', '#46f0f0',
+  '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8',
+  '#800000', '#aaffc3', '#808000', '#ffd8b1', '#000075', '#808080', '#ffffff',
+  '#000000'
 ];
 
 // implement rectangle and point

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -701,55 +701,31 @@
 
         <hr style="border-color: grey">
 
-
-          <div id="date-radio">
-            <!-- make a v-radio-group with 3 options -->
-          <h2>Notable Dates</h2>
-          <v-radio-group
-            v-model="radio"
-            row
+        <div id="sample-info" v-if="selections" style="margin-top: 1em;">
+          <v-select
+            v-model="selection as SelectionOption"
+            :items="selectionOptions"
+            label="Selection"
+            return-object
           >
-            <div v-for = "(event, index) in interestingEvents" :key="index" class="d-flex flex-row align-center">
-              <v-radio
-                :class="event.highlighted ? 'highlighted' : ''"
-                :label="event.label"
-                :value="index"
-                @keyup.enter="radio = index"
-              >
-              </v-radio>
-              <info-button>
-                <div style="display: inline-block; margin: 0; padding: 0;" v-html="event.info"></div>
-              </info-button>
-            </div>
-            
-          </v-radio-group>
-        </div>
-        
-        <hr style="border-color: grey;"  v-if="radio !== null ">
-        
-        <div id="locations-of-interest" v-if="radio !== null">
-          <h3 class="mb-1">Featured Events for {{ dateStrings[radio] }}</h3>
-          <v-radio-group
-            v-if="radio !== null"
-            v-model="sublocationRadio"
-            row
-          >
-          <div
-            v-for="(loi, index) in locationsOfInterest[radio]" 
-            v-bind:key="index" 
-            class="sublocation-radio-wrapper d-flex flex-row align-center space-between">
-            <v-radio
-              class="sublocation-radio"
-              :label="loi.text"
-              :value="index"
-              @keyup.enter="sublocationRadio = index"
-            ></v-radio>
-            <info-button>
-              <p v-html="locationsOfInterestText[radio][index]"></p>
-            </info-button>
+            <template #selection="{ item }">
+              {{ item.value == null ? "None" : item.value.name }}
+            </template>
+            <template #item="{ item, props }">
+              <v-list-item :title="item.value == null ? 'None' : item.value.name" @click="props.onClick"></v-list-item>
+            </template>
+          </v-select>
+            <v-btn size="small" color="primary" @click="fetchRectangleSamples" :loading="loadingSamples === 'loading'" :disabled="loadingSamples === 'loading' || selection?.samples">
+              Get NO₂ Samples
+            </v-btn>
+            <v-btn size="small" color="primary" @click="fetchCenterPointSample" :loading="loadingPointSample === 'loading'" :disabled="loadingPointSample === 'loading'">
+              Get Center Point NO₂ Sample
+            </v-btn>
+            <v-btn size="small" color="primary" @click="samplesGraph = true" :disabled="!haveSamples">
+              Show Timeseries
+            </v-btn>
+  
           </div>
-          </v-radio-group>
-        </div>
 
         <hr style="border-color: grey;">
         <div id="bottom-options">
@@ -782,31 +758,7 @@
         </div>
       </div>
       
-      <div id="sample-info" v-if="selections" style="margin-top: 1em;">
-        <v-select
-          v-model="selection as SelectionOption"
-          :items="selectionOptions"
-          label="Selection"
-          return-object
-        >
-          <template #selection="{ item }">
-            {{ item.value == null ? "None" : item.value.name }}
-          </template>
-          <template #item="{ item, props }">
-            <v-list-item :title="item.value == null ? 'None' : item.value.name" @click="props.onClick"></v-list-item>
-          </template>
-        </v-select>
-          <v-btn size="small" color="primary" @click="fetchRectangleSamples" :loading="loadingSamples === 'loading'" :disabled="loadingSamples === 'loading' || selection?.samples">
-            Get NO₂ Samples
-          </v-btn>
-          <v-btn size="small" color="primary" @click="fetchCenterPointSample" :loading="loadingPointSample === 'loading'" :disabled="loadingPointSample === 'loading'">
-            Get Center Point NO₂ Sample
-          </v-btn>
-          <v-btn size="small" color="primary" @click="samplesGraph = true" :disabled="!haveSamples">
-            Show Timeseries
-          </v-btn>
 
-        </div>
         <cds-dialog 
           title="NO₂ Samples" 
           v-model="sampleDialog" 
@@ -1623,25 +1575,6 @@ onMounted(() => {
 
 const datesOfInterest = computed(() => {
   return interestingEvents.map(event => event.date);
-});
-
-const dateStrings = computed(() => {
-  return interestingEvents.map(event => event.dateString);
-});
-
-const locationsOfInterest = computed(() => {
-  return interestingEvents.map(event =>
-    event.locations.map(loc => ({
-      ...loc,
-      index: nearestDateIndex(new Date(loc.time)),
-    }))
-  );
-});
-
-const locationsOfInterestText = computed(() => {
-  return interestingEvents.map(event =>
-    event.locations.map(loc => loc.description)
-  );
 });
 
 const dateIsDST = computed(() => {

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1521,7 +1521,11 @@ function fetchRectangleSamples() {
     end
   ).then((samples) => {
     selections.value[index].samples = samples;
-    selections.value[index].errors = Array(Object.keys(samples).length).fill(testError);
+    const errors = {};
+    for (const key in samples) {
+      errors[key] = testError;
+    }
+    selections.value[index].errors = errors;
     loadingSamples.value = "finished";
   }).catch((error) => {
     sampleError.value = error?.message || String(error);
@@ -2241,8 +2245,8 @@ watch(selectionInfo, (info: RectangleSelectionInfo | null) => {
     return;
   }
   if (selectedIndex.value === null) {
-    selectionCount += 1;
     const color = COLORS[selectionCount % COLORS.length];
+    selectionCount += 1;
     const { layer } = addRectangleLayer(map.value, info, color);
     selections.value.push({
       id: v4(),

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -12,11 +12,10 @@ import { onMounted, ref } from "vue";
 import { v4 } from "uuid";
 import { PlotlyHTMLElement, newPlot, type Data, type Datum, type PlotMouseEvent } from "plotly.js-dist-min";
 
-import { AggValue } from "../esri/imageServer/esriGetSamples";
+import { AggValue, RectangleSelection } from "../types";
 
 interface TimeseriesProps {
-  data: Record<number, AggValue>;
-  errors?: Record<number, { lower: number, higher: number }>;
+  data: RectangleSelection[];
 }
 
 const props = defineProps<TimeseriesProps>();
@@ -36,63 +35,71 @@ function datumToDate(datum: Datum): Date | null {
   return new Date(datum);
 }
 
+const legendGroups: Record<string, string> = {};
+
 onMounted(() => {
-  const ts = Object.keys(props.data).sort();
-  const dataT: Date[] = [];
-  const dataV: (number | null)[] = [];
-  ts.forEach(t => {
-    const point: AggValue = props.data[t];
-    dataT.push(point.date);
-    dataV.push(point.value);
-  });
-  const legendGroup = v4();
-  const plotlyData: Data[] = [{
-    x: dataT,
-    y: dataV,
-    mode: "lines+markers",
-    legendgroup: legendGroup,
-  }];
 
-  const errors = props.errors;
-  if (errors != null) {
-    const upperY: (number | null)[] = [];
-    const lowerY: (number | null)[] = [];
-
+  props.data.forEach(data => {
+    const ts = Object.keys(data).sort();
+    const dataT: Date[] = [];
+    const dataV: (number | null)[] = [];
     ts.forEach(t => {
-      const point: AggValue = props.data[t];
-      const value = point.value;
-      const errs = errors[t];
-      if (value === null || errs == null) {
-        lowerY.push(null);
-        upperY.push(null);
-        return;
-      }
-      const { lower, upper } = errs;
-      const valueLower = value - lower;
-      const valueHigher = value + upper;
-      lowerY.push(Math.min(valueLower, valueHigher));
-      upperY.push(Math.max(valueLower, valueHigher));
+      const point: AggValue = data[t];
+      dataT.push(point.date);
+      dataV.push(point.value);
     });
 
-    plotlyData.push({
+    const legendGroup = v4();
+    legendGroups[data.id] = legendGroup;
+    const plotlyData: Data[] = [{
       x: dataT,
-      y: lowerY,
-      mode: "lines",
-      line: { width: 0 },
-      showlegend: false,
+      y: dataV,
+      mode: "lines+markers",
       legendgroup: legendGroup,
-    });
+      name: data.name,
+    }];
 
-    plotlyData.push({
-      x: dataT,
-      y: upperY,
-      mode: "lines",
-      line: { width: 0 },
-      fill: "tonexty",
-      showlegend: false,
-      legendgroup: legendGroup,
-    });
-  }
+    const errors = data.errors;
+    if (errors != null) {
+      const upperY: (number | null)[] = [];
+      const lowerY: (number | null)[] = [];
+
+      ts.forEach(t => {
+        const point: AggValue = data[t];
+        const value = point.value;
+        const errs = errors[t];
+        if (value === null || errs == null) {
+          lowerY.push(null);
+          upperY.push(null);
+          return;
+        }
+        const { lower, upper } = errs;
+        const valueLower = value - lower;
+        const valueHigher = value + upper;
+        lowerY.push(Math.min(valueLower, valueHigher));
+        upperY.push(Math.max(valueLower, valueHigher));
+      });
+
+      plotlyData.push({
+        x: dataT,
+        y: lowerY,
+        mode: "lines",
+        line: { width: 0 },
+        showlegend: false,
+        legendgroup: legendGroup,
+      });
+
+      plotlyData.push({
+        x: dataT,
+        y: upperY,
+        mode: "lines",
+        line: { width: 0 },
+        fill: "tonexty",
+        showlegend: false,
+        legendgroup: legendGroup,
+      });
+    }
+  });
 
   const layout = {
     width: 600,

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -72,7 +72,7 @@ onMounted(() => {
       const lowerY: (number | null)[] = [];
 
       ts.forEach(t => {
-        const point: AggValue = data[t];
+        const point: AggValue = samples[t];
         const value = point.value;
         const errs = errors[t];
         if (value === null || errs == null) {

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -41,6 +41,7 @@ onMounted(() => {
 
   const plotlyData: Data[] = [];
 
+  let max = 0;
   props.data.forEach(data => {
     const samples = data.samples;
     if (!samples) { return; }
@@ -52,6 +53,7 @@ onMounted(() => {
       dataT.push(point.date);
       dataV.push(point.value);
     });
+    max = Math.max(max, Math.max(...dataV));
 
     const legendGroup = v4();
     legendGroups[data.id] = legendGroup;
@@ -117,6 +119,9 @@ onMounted(() => {
   const layout = {
     width: 600,
     height: 400,
+    yaxis: {
+      range: [0, 1.2 * max],
+    }
   };
 
   newPlot(graph.value ?? id, plotlyData, layout).then((el: PlotlyHTMLElement) => {

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -39,25 +39,32 @@ const legendGroups: Record<string, string> = {};
 
 onMounted(() => {
 
+  const plotlyData: Data[] = [];
+
   props.data.forEach(data => {
-    const ts = Object.keys(data).sort();
+    const samples = data.samples;
+    if (!samples) { return; }
+    const ts = Object.keys(samples).sort();
     const dataT: Date[] = [];
     const dataV: (number | null)[] = [];
     ts.forEach(t => {
-      const point: AggValue = data[t];
+      const point: AggValue = samples[t];
       dataT.push(point.date);
       dataV.push(point.value);
     });
 
     const legendGroup = v4();
     legendGroups[data.id] = legendGroup;
-    const plotlyData: Data[] = [{
+    plotlyData.push({
       x: dataT,
       y: dataV,
       mode: "lines+markers",
       legendgroup: legendGroup,
       name: data.name,
-    }];
+      marker: {
+        color: data.color,
+      },
+    });
 
     const errors = data.errors;
     if (errors != null) {
@@ -87,6 +94,9 @@ onMounted(() => {
         line: { width: 0 },
         showlegend: false,
         legendgroup: legendGroup,
+        marker: {
+          color: data.color,
+        },
       });
 
       plotlyData.push({
@@ -97,6 +107,9 @@ onMounted(() => {
         fill: "tonexty",
         showlegend: false,
         legendgroup: legendGroup,
+        marker: {
+          color: data.color,
+        },
       });
     }
   });

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -1,12 +1,8 @@
 import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { type LatLng, LatLngBounds, type LeafletMouseEvent, Map, Rectangle } from "leaflet";
 
-export interface RectangleSelectionInfo {
-  xmin: number;
-  xmax: number;
-  ymin: number;
-  ymax: number;
-}
+import { RectangleSelectionInfo } from "../../types";
+
 
 export function useRectangleSelection(
   map: Ref<Map | null>, 

--- a/src/composables/leaflet/utils.ts
+++ b/src/composables/leaflet/utils.ts
@@ -18,6 +18,7 @@ export function addRectangleLayer(
   rect.setStyle({
     fill: true,
     fillOpacity: 0.7,
+    weight: 0,
     color,
   });
   map.addLayer(rect);

--- a/src/composables/leaflet/utils.ts
+++ b/src/composables/leaflet/utils.ts
@@ -1,0 +1,20 @@
+import { LatLng, LatLngBounds, Map, Rectangle } from "leaflet";
+import { RectangleSelectionInfo } from "../../types";
+
+export function addRectangleLayer(
+  map: Map,
+  info: RectangleSelectionInfo,
+  color: string,
+) {
+  const southwest = new LatLng(info.ymin, info.xmin);
+  const northeast = new LatLng(info.ymax, info.xmax);
+  const bounds = new LatLngBounds(southwest, northeast);
+  const rect = new Rectangle(bounds);
+  rect.setStyle({
+    fill: true,
+    fillOpacity: 0.7,
+    color,
+  });
+  map.addLayer(rect);
+  return { layer: rect };
+}

--- a/src/composables/leaflet/utils.ts
+++ b/src/composables/leaflet/utils.ts
@@ -31,3 +31,10 @@ export function updateRectangleBounds(
 ) {
   rectangle.setBounds(createBounds(info)); 
 }
+
+export function removeRectangleLayer(
+  map: Map,
+  rect: Rectangle
+) {
+  map.removeLayer(rect);
+}

--- a/src/composables/leaflet/utils.ts
+++ b/src/composables/leaflet/utils.ts
@@ -1,14 +1,19 @@
 import { LatLng, LatLngBounds, Map, Rectangle } from "leaflet";
 import { RectangleSelectionInfo } from "../../types";
 
+
+function createBounds(info: RectangleSelectionInfo): LatLngBounds {
+  const southwest = new LatLng(info.ymin, info.xmin);
+  const northeast = new LatLng(info.ymax, info.xmax);
+  return new LatLngBounds(southwest, northeast);
+}
+
 export function addRectangleLayer(
   map: Map,
   info: RectangleSelectionInfo,
   color: string,
 ) {
-  const southwest = new LatLng(info.ymin, info.xmin);
-  const northeast = new LatLng(info.ymax, info.xmax);
-  const bounds = new LatLngBounds(southwest, northeast);
+  const bounds = createBounds(info);
   const rect = new Rectangle(bounds);
   rect.setStyle({
     fill: true,
@@ -17,4 +22,11 @@ export function addRectangleLayer(
   });
   map.addLayer(rect);
   return { layer: rect };
+}
+
+export function updateRectangleBounds(
+  rectangle: Rectangle,
+  info: RectangleSelectionInfo
+) {
+  rectangle.setBounds(createBounds(info)); 
 }

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -2,7 +2,8 @@ import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { GeoJSONSource, LngLat, Map, MapMouseEvent } from "maplibre-gl";
 import { v4 } from "uuid";
 
-import { RectangleSelectionInfo } from "../../types";
+import type { RectangleSelectionInfo } from "../../types";
+import type { LayerType } from "./utils";
 
 
 export function useRectangleSelection(
@@ -11,12 +12,8 @@ export function useRectangleSelection(
   startActive: boolean = false,
 ) {
 
-  // StyleLayer isn't exported
-  const layerGetter = (m: Map, id: string) => m.getLayer(id);
-  type LayerType = ReturnType<typeof layerGetter>;
-
   let rectangleSource: GeoJSONSource | null = null;
-  let rectangleLayer: LayerType = undefined;
+  let rectangleLayer: LayerType | undefined = undefined;
   let startCoords: LngLat | null = null;
   let geoJson: GeoJSON.FeatureCollection;
   const selectionInfo = ref<RectangleSelectionInfo | null>(null);

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -2,12 +2,8 @@ import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
 import { GeoJSONSource, LngLat, Map, MapMouseEvent } from "maplibre-gl";
 import { v4 } from "uuid";
 
-export interface RectangleSelectionInfo {
-  xmin: number;
-  xmax: number;
-  ymin: number;
-  ymax: number;
-}
+import { RectangleSelectionInfo } from "../../types";
+
 
 export function useRectangleSelection(
   map: Ref<Map | null>,

--- a/src/composables/maplibre/utils.ts
+++ b/src/composables/maplibre/utils.ts
@@ -74,3 +74,11 @@ export function updateRectangleBounds(
     source.setData(geoJson);
   });
 }
+
+export function removeRectangleLayer(
+  map: Map,
+  source: GeoJSONSource,
+) {
+  map.removeLayer(source.id);
+  map.removeSource(source.id);
+}

--- a/src/composables/maplibre/utils.ts
+++ b/src/composables/maplibre/utils.ts
@@ -1,0 +1,50 @@
+import { GeoJSONSource, Map } from "maplibre-gl";
+import { v4 } from "uuid";
+
+import { RectangleSelectionInfo } from "../../types";
+
+
+export function addRectangleLayer(
+  map: Map,
+  info: RectangleSelectionInfo,
+  color: string,
+) {
+  
+  const uuid = v4();
+  const geoJson: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: [{
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [[
+          [info.xmin, info.ymin],
+          [info.xmax, info.ymin],
+          [info.xmax, info.ymax],
+          [info.xmin, info.ymax],
+          [info.xmin, info.ymin],
+        ]],
+      },
+      properties: {},
+    }],
+  };
+
+  map.addSource(uuid, {
+    type: "geojson",
+    data: geoJson,
+  });
+  const source = map.getSource(uuid) as GeoJSONSource;
+
+  map.addLayer({
+    id: uuid,
+    type: "fill",
+    source: uuid,
+    paint: {
+      "fill-color": color,
+      "fill-opacity": 0.7,
+    }
+  });
+  const layer = map.getLayer(uuid);
+
+  return { layer, source };
+}

--- a/src/composables/maplibre/utils.ts
+++ b/src/composables/maplibre/utils.ts
@@ -2,7 +2,9 @@ import { GeoJSONSource, Map } from "maplibre-gl";
 import { v4 } from "uuid";
 
 import { RectangleSelectionInfo } from "../../types";
-import { geoJson } from "leaflet";
+
+const layerGetter = (m: Map, id: string) => m.getLayer(id);
+export type LayerType = Exclude<ReturnType<typeof layerGetter>, undefined>;
 
 function createBounds(info: RectangleSelectionInfo) {
   return [
@@ -49,12 +51,10 @@ export function addRectangleLayer(
     paint: {
       "fill-color": color,
       "fill-opacity": 0.7,
-      "line-width": 0,
     }
   });
-  const layer = map.getLayer(uuid);
 
-  return { layer, source };
+  return { layer: source };
 }
 
 export function updateRectangleBounds(
@@ -77,8 +77,8 @@ export function updateRectangleBounds(
 
 export function removeRectangleLayer(
   map: Map,
-  source: GeoJSONSource,
+  layer: LayerType,
 ) {
-  map.removeLayer(source.id);
-  map.removeSource(source.id);
+  map.removeLayer(layer.id);
+  map.removeSource(layer.id);
 }

--- a/src/composables/maplibre/utils.ts
+++ b/src/composables/maplibre/utils.ts
@@ -2,6 +2,17 @@ import { GeoJSONSource, Map } from "maplibre-gl";
 import { v4 } from "uuid";
 
 import { RectangleSelectionInfo } from "../../types";
+import { geoJson } from "leaflet";
+
+function createBounds(info: RectangleSelectionInfo) {
+  return [
+    [info.xmin, info.ymin],
+    [info.xmax, info.ymin],
+    [info.xmax, info.ymax],
+    [info.xmin, info.ymax],
+    [info.xmin, info.ymin],
+  ];
+}
 
 
 export function addRectangleLayer(
@@ -17,13 +28,9 @@ export function addRectangleLayer(
       type: "Feature",
       geometry: {
         type: "Polygon",
-        coordinates: [[
-          [info.xmin, info.ymin],
-          [info.xmax, info.ymin],
-          [info.xmax, info.ymax],
-          [info.xmin, info.ymax],
-          [info.xmin, info.ymin],
-        ]],
+        coordinates: [
+          createBounds(info),
+        ],
       },
       properties: {},
     }],
@@ -47,4 +54,22 @@ export function addRectangleLayer(
   const layer = map.getLayer(uuid);
 
   return { layer, source };
+}
+
+export function updateRectangleBounds(
+  source: GeoJSONSource,
+  info: RectangleSelectionInfo,
+) {
+  source.getData().then(data => {
+    const geoJson = data as GeoJSON.FeatureCollection;
+    geoJson.features[0] = {
+      ...geoJson.features[0],
+      geometry: {
+        type: "Polygon",
+        coordinates: [createBounds(info)],
+      }
+    };
+
+    source.setData(geoJson);
+  });
 }

--- a/src/composables/maplibre/utils.ts
+++ b/src/composables/maplibre/utils.ts
@@ -49,6 +49,7 @@ export function addRectangleLayer(
     paint: {
       "fill-color": color,
       "fill-opacity": 0.7,
+      "line-width": 0,
     }
   });
   const layer = map.getLayer(uuid);

--- a/src/esri/imageServer/esriGetSamples.ts
+++ b/src/esri/imageServer/esriGetSamples.ts
@@ -198,10 +198,7 @@ function nullMean(samples: (number | null)[]): number | null {
   return sum / validSamples.length;
 }
 
-export type AggValue = {
-  value: number | null;
-  date: Date;
-};
+
 export function aggregate(
   grouped: Map<number, CEsriTimeseries[]>,
   aggFunction: (samples: CEsriTimeseries[]) => number | null,

--- a/src/esri/imageServer/esriGetSamples.ts
+++ b/src/esri/imageServer/esriGetSamples.ts
@@ -2,6 +2,7 @@
 import { rectangleToGeometry, pointToGeometry } from '../geometry';
 import type { RectBounds, PointBounds, EsriGeometryType } from '../geometry';
 import type { EsriGetSamplesReturn, EsriGetSamplesReturnError, EsriGetSamplesSample, Variables, EsriInterpolationMethod, CEsriTimeseries } from '../types';
+import type { AggValue } from "../../types";
 
 function safeParseNumber(value: string | null | undefined): number | null {
   if (value === null || value === '' || value === undefined) return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type MapType<T extends MappingBackends> =
 
 export type RectangleType<T extends MappingBackends> =
   T extends 'leaflet' ? Rectangle :
-  T extends 'maplibre' ? Rect :
+  T extends 'maplibre' ? GeoJSONSource:
   never;
 
 export function isLeaflet<T extends MappingBackends>(backend: Ref<T> | T, map: unknown): map is MapType<'leaflet'> {
@@ -119,12 +119,12 @@ export interface DataPointError {
   higher: number;
 }
 
-export interface RectangleSelection {
+export interface RectangleSelection<T extends MappingBackends> {
   id: string;
   name: string;
   rectangle: RectangleSelectionInfo;
   color: string;
-  layer?: Rectangle;
+  layer?: RectangleType<T>;
   source?: GeoJSONSource;
   samples?: Record<number, AggValue>;
   errors?: Record<number, DataPointError>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
-
 // Types
+
+import L, { Rectangle } from 'leaflet';
+import M, { GeoJSONSource, Rect } from 'maplibre-gl';
+import { Ref, toValue } from 'vue';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type Prettify<T> = { [K in keyof T]: T[K]; } & {};
@@ -19,32 +22,35 @@ export interface InitMapOptions {
   zoom: number,
   t?: number | null,
 }
+
 export interface LocationOfInterest {
-    latlng: LatLngPair;
-    zoom: number;
-    text: string;
-    description: string;
-    time: string;
-    index?: number;
-  }
+  latlng: LatLngPair;
+  zoom: number;
+  text: string;
+  description: string;
+  time: string;
+  index?: number;
+}
+
 export interface InterestingEvent {
-    date: Date;
-    endDate?: Date;
-    dateString: string;
-    locations: LocationOfInterest[];
-    label?: string;
-    info?: string;
-    highlighted?: boolean;
-    hasFeature?: boolean;
-  }
-  
-import L from 'leaflet';
-import M from 'maplibre-gl';
-import { Ref, toValue } from 'vue';
+  date: Date;
+  endDate?: Date;
+  dateString: string;
+  locations: LocationOfInterest[];
+  label?: string;
+  info?: string;
+  highlighted?: boolean;
+  hasFeature?: boolean;
+}
 
 export type MapType<T extends MappingBackends> = 
   T extends 'leaflet' ? L.Map :
   T extends 'maplibre' ? M.Map :
+  never;
+
+export type RectangleType<T extends MappingBackends> =
+  T extends 'leaflet' ? Rectangle :
+  T extends 'maplibre' ? Rect :
   never;
 
 export function isLeaflet<T extends MappingBackends>(backend: Ref<T> | T, map: unknown): map is MapType<'leaflet'> {
@@ -101,4 +107,25 @@ export interface RectangleSelectionInfo {
   xmax: number;
   ymin: number;
   ymax: number;
+}
+
+export type AggValue = {
+  value: number | null;
+  date: Date;
+};
+
+export interface DataPointError {
+  lower: number;
+  higher: number;
+}
+
+export interface RectangleSelection {
+  id: string;
+  name: string;
+  rectangle: RectangleSelectionInfo;
+  color: string;
+  layer?: Rectangle;
+  source?: GeoJSONSource;
+  samples?: Record<number, AggValue>;
+  errors?: Record<number, DataPointError>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,3 +95,10 @@ export interface DragInfo {
   oldTransition?: string;
   overlays: NodeList;
 }
+
+export interface RectangleSelectionInfo {
+  xmin: number;
+  xmax: number;
+  ymin: number;
+  ymax: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Types
 
 import L, { Rectangle } from 'leaflet';
-import M, { GeoJSONSource, Rect } from 'maplibre-gl';
+import M, { GeoJSONSource } from 'maplibre-gl';
 import { Ref, toValue } from 'vue';
 
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
This PR updates the app to allow making multiple selections. Selection is now deactivated by default, and can be activated by a button in a new toolbar for the map viewer. Similar to the glue selection tools, selection is deactivated after a region is selected, though it would be trivial to change this.

I've removed the "locations of interest" piece of the UI, and replaced it with two items:
* A dropdown selector that picks which selection is "active" (or "None"). If a selection is active, then using the selection tool will update the bounds for that selection. If "None" is selected, then a new selection region is created.
* A list which shows the selection regions that currently exist. Fetching samples for the region and the center point, as well as removing the selection region, are exposed as actions in the list item. I've used icon buttons with tooltips as the interaction elements; feel free to change the icons or tooltip text.

This should all work with either Leaflet or MapLibre - to switch backends, all you need to do is switch out the relevant imports and change the value of the `BACKEND` constant to the appropriate string (for TypeScript purposes).

Everything is very much assuming that the selections are rectangles right now - if we allow arbitrary shapes in the future, I don't think it would be too painful to make this all shape-agnostic, but I don't want to make things too abstract until we're actually planning on doing that. Colors are generated in a cycle from the `COLORS` list - feel free to adjust this list.