### PR TITLE
Add point selection tool

### DIFF
--- a/src/composables/leaflet/baseUseSelection.ts
+++ b/src/composables/leaflet/baseUseSelection.ts
@@ -1,0 +1,76 @@
+import { onMounted, onUnmounted, ref, watch } from "vue";
+import { type LeafletMouseEvent, Map } from "leaflet";
+
+import { UseSelectionOptions } from "../../types";
+
+export function baseUseSelection<SelectionInfo>(
+  options: UseSelectionOptions<Map, LeafletMouseEvent, SelectionInfo>,
+) {
+
+  const { map, handler, startActive } = options;
+  const active = ref(startActive ?? false);
+
+  onMounted(() => {
+    const lMap = map.value;
+    if (active.value && lMap) {
+      updateListeners(lMap, active.value);
+    }
+  });
+
+  function updateListeners(map: Map, active: boolean) {
+    if (active) {
+      map.dragging.disable();
+      map.scrollWheelZoom.disable();
+      if (handler.onMouseup) {
+        map.addEventListener("mouseup", handler.onMouseup);
+      }
+      if (handler.onMousedown) {
+        map.addEventListener("mousedown", handler.onMousedown);
+      }
+      if (handler.onMousemove) {
+        map.addEventListener("mousedown", handler.onMousemove);
+      }
+    } else {
+      map.dragging.enable();
+      map.scrollWheelZoom.enable();
+      if (handler.onMouseup) {
+        map.removeEventListener("mouseup", handler.onMouseup);
+      }
+      if (handler.onMousedown) {
+        map.removeEventListener("mousedown", handler.onMousedown);
+      }
+      if (handler.onMousemove) {
+        map.removeEventListener("mousedown", handler.onMousemove);
+      }
+    }
+  }
+
+  watch(active, (nowActive: boolean) => {
+    const lMap = map.value;
+    if (lMap !== null) {
+      updateListeners(lMap, nowActive);
+    }
+  });
+
+  // If we're going to take in the map as a ref,
+  // we might as well update if its value does
+  watch(map, (newMap: Map | null) => {
+    if (newMap !== null) {
+      updateListeners(newMap, active.value);
+    }
+  });
+
+  onUnmounted(() => {
+    // The map will probably be destroyed along with the component using this composable
+    // But if not, we should remove handlers
+    const lMap = map.value;
+    if (lMap !== null && active.value) {
+      updateListeners(lMap, false);
+    }
+  });
+
+  return {
+    active,
+    selectionInfo: handler.selectionInfo,
+  };
+}

--- a/src/composables/leaflet/baseUseSelection.ts
+++ b/src/composables/leaflet/baseUseSelection.ts
@@ -21,6 +21,7 @@ export function baseUseSelection<SelectionInfo>(
     if (active) {
       map.dragging.disable();
       map.scrollWheelZoom.disable();
+      console.log(handler);
       if (handler.onMouseup) {
         map.addEventListener("mouseup", handler.onMouseup);
       }
@@ -28,7 +29,7 @@ export function baseUseSelection<SelectionInfo>(
         map.addEventListener("mousedown", handler.onMousedown);
       }
       if (handler.onMousemove) {
-        map.addEventListener("mousedown", handler.onMousemove);
+        map.addEventListener("mousemove", handler.onMousemove);
       }
     } else {
       map.dragging.enable();
@@ -40,7 +41,7 @@ export function baseUseSelection<SelectionInfo>(
         map.removeEventListener("mousedown", handler.onMousedown);
       }
       if (handler.onMousemove) {
-        map.removeEventListener("mousedown", handler.onMousemove);
+        map.removeEventListener("mousemove", handler.onMousemove);
       }
     }
   }

--- a/src/composables/leaflet/usePointSelection.ts
+++ b/src/composables/leaflet/usePointSelection.ts
@@ -1,0 +1,67 @@
+import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
+import { type LeafletMouseEvent, Map, Point } from "leaflet";
+
+import { PointSelectionInfo } from "../../types";
+
+export function usePointSelection(
+  map: Ref<Map | null>,
+  startActive: boolean = false,
+) {
+  const active = ref(startActive);
+  const selectionInfo = ref<PointSelectionInfo | null>(null);
+
+  onMounted(() => {
+    const lMap = map.value;
+    if (active.value && lMap) {
+      updateListeners(lMap, active.value);
+    }
+  });
+
+  function onMouseup(event: LeafletMouseEvent) {
+    selectionInfo.value = {
+      x: event.latlng.lng,
+      y: event.latlng.lat,
+    };
+  }
+
+  function updateListeners(map: Map, active: boolean) {
+    if (active) {
+      map.dragging.disable();
+      map.scrollWheelZoom.disable();
+      map.addEventListener("mouseup", onMouseup);
+    } else {
+      map.dragging.enable();
+      map.scrollWheelZoom.enable();
+      map.removeEventListener("mouseup", onMouseup);
+    }
+  }
+
+  watch(active, (nowActive: boolean) => {
+    const lMap = map.value;
+    if (lMap !== null) {
+      updateListeners(lMap, nowActive);
+    }
+  });
+
+  // If we're going to take in the map as a ref,
+  // we might as well update if its value does
+  watch(map, (newMap: Map | null) => {
+    if (newMap !== null) {
+      updateListeners(newMap, active.value);
+    }
+  });
+
+  onUnmounted(() => {
+    // The map will probably be destroyed along with the component using this composable
+    // But if not, we should remove handlers
+    const lMap = map.value;
+    if (lMap !== null && active.value) {
+      updateListeners(lMap, false);
+    }
+  });
+
+  return {
+    selectionInfo,
+    active,
+  };
+}

--- a/src/composables/leaflet/usePointSelection.ts
+++ b/src/composables/leaflet/usePointSelection.ts
@@ -14,7 +14,7 @@ export function usePointSelection(
     selectionInfo: ref<PointSelectionInfo | null>(null),
 
     onMouseup(event: LeafletMouseEvent) {
-      this.selectionInfo.value = {
+      handler.selectionInfo.value = {
         x: event.latlng.lng,
         y: event.latlng.lat,
       };

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -1,8 +1,8 @@
-import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
+import { ref, type Ref } from "vue";
 import { type LatLng, LatLngBounds, type LeafletMouseEvent, Map, Rectangle } from "leaflet";
 
-import { RectangleSelectionInfo } from "../../types";
-
+import { RectangleSelectionInfo, SelectionHandler } from "../../types";
+import { baseUseSelection } from "./baseUseSelection";
 
 export function useRectangleSelection(
   map: Ref<Map | null>, 
@@ -11,98 +11,50 @@ export function useRectangleSelection(
 ) {
   let rect: Rectangle | null = null;
   let startCoords: LatLng | null = null;
-  const selectionInfo = ref<RectangleSelectionInfo | null>(null);
-  const active = ref(startActive);
 
-  onMounted(() => {
-    const lMap = map.value;
-    if (active.value && lMap) {
-      updateListeners(lMap, active.value);
+  const handler: SelectionHandler<LeafletMouseEvent, RectangleSelectionInfo> = {
+    
+    selectionInfo: ref<RectangleSelectionInfo | null>(null),
+
+    onMousedown(event: LeafletMouseEvent) {
+      startCoords = event.latlng;
+      rect = new Rectangle(new LatLngBounds(startCoords, startCoords));
+      rect.setStyle({
+        weight: 1,
+        fillOpacity: 0,
+        dashArray: [5, 5],
+        color: interactColor,
+      });
+      map.value?.addLayer(rect);
+    },
+
+    onMouseup(event: LeafletMouseEvent) {
+      if (startCoords === null) {
+        return;
+      }
+
+      const eventCoords = event.latlng;
+      this.selectionInfo.value = {
+        xmin: startCoords.lng,
+        ymin: startCoords.lat,
+        xmax: eventCoords.lng,
+        ymax: eventCoords.lat,
+      };
+
+      if (rect) {
+        map.value?.removeLayer(rect);
+        rect = null;
+      }
+      startCoords = null;
+    },
+
+    onMousemove(event: LeafletMouseEvent) {
+      if (startCoords === null || rect === null) {
+        return;
+      }
+      rect.setBounds(new LatLngBounds(startCoords, event.latlng));
     }
-  });
-
-  function onMousedown(event: LeafletMouseEvent) {
-    startCoords = event.latlng;
-    rect = new Rectangle(new LatLngBounds(startCoords, startCoords));
-    rect.setStyle({
-      weight: 1,
-      fillOpacity: 0,
-      dashArray: [5, 5],
-      color: interactColor,
-    });
-    map.value?.addLayer(rect);
-  }
-
-  function onMouseup(event: LeafletMouseEvent) {
-    if (startCoords === null) {
-      return;
-    }
-
-    const eventCoords = event.latlng;
-    selectionInfo.value = {
-      xmin: startCoords.lng,
-      ymin: startCoords.lat,
-      xmax: eventCoords.lng,
-      ymax: eventCoords.lat,
-    };
-
-    if (rect) {
-      map.value?.removeLayer(rect);
-      rect = null;
-    }
-    startCoords = null;
-  }
-
-  function onMousemove(event: LeafletMouseEvent) {
-    if (startCoords === null || rect === null) {
-      return;
-    }
-    rect.setBounds(new LatLngBounds(startCoords, event.latlng));
-  }
-
-  function updateListeners(map: Map, active: boolean) {
-    if (active) {
-      map.dragging.disable();
-      map.scrollWheelZoom.disable();
-      map.addEventListener("mousedown", onMousedown);
-      map.addEventListener("mouseup", onMouseup);
-      map.addEventListener("mousemove", onMousemove);
-    } else {
-      map.dragging.enable();
-      map.scrollWheelZoom.enable();
-      map.removeEventListener("mousedown", onMousedown);
-      map.removeEventListener("mouseup", onMouseup);
-      map.removeEventListener("mousemove", onMousemove);
-    }
-  }
-
-  watch(active, (nowActive: boolean) => {
-    const lMap = map.value;
-    if (lMap !== null) {
-      updateListeners(lMap, nowActive);
-    }
-  });
-
-  // If we're going to take in the map as a ref,
-  // we might as well update if its value does
-  watch(map, (newMap: Map | null) => {
-    if (newMap !== null) {
-      updateListeners(newMap, active.value);
-    }
-  });
-
-  onUnmounted(() => {
-    // The map will probably be destroyed along with the component using this composable
-    // But if not, we should remove handlers
-    const lMap = map.value;
-    if (lMap !== null && active.value) {
-      updateListeners(lMap, false);
-    }
-  });
-
-  return {
-    selectionInfo,
-    active,
   };
 
+  return baseUseSelection({ map, handler, startActive });
 }

--- a/src/composables/leaflet/useRectangleSelection.ts
+++ b/src/composables/leaflet/useRectangleSelection.ts
@@ -34,7 +34,7 @@ export function useRectangleSelection(
       }
 
       const eventCoords = event.latlng;
-      this.selectionInfo.value = {
+      handler.selectionInfo.value = {
         xmin: startCoords.lng,
         ymin: startCoords.lat,
         xmax: eventCoords.lng,

--- a/src/composables/maplibre/baseUseSelection.ts
+++ b/src/composables/maplibre/baseUseSelection.ts
@@ -1,0 +1,77 @@
+import { onMounted, onUnmounted, ref, watch } from "vue";
+import { Map, MapMouseEvent } from "maplibre-gl";
+
+import { UseSelectionOptions } from "../../types";
+
+export function baseUseSelection<SelectionInfo>(
+  options: UseSelectionOptions<Map, MapMouseEvent, SelectionInfo>,
+) {
+
+  const { map, handler, startActive } = options;
+  const active = ref(startActive ?? false);
+
+  onMounted(() => {
+    const mMap = map.value;
+    if (active.value && mMap) {
+      updateListeners(mMap, active.value);
+    }
+  });
+
+  function updateListeners(map: Map, active: boolean) {
+    if (active) {
+      map.dragPan.disable();
+      map.scrollZoom.disable();
+      if (handler.onMousedown) {
+        map.on("mousedown", handler.onMousedown);
+      }
+      if (handler.onMouseup) {
+        map.on("mouseup", handler.onMouseup);
+      }
+      if (handler.onMousemove) {
+        map.on("mousemove", handler.onMousemove);
+      }
+    } else {
+      map.dragPan.enable();
+      map.scrollZoom.enable();
+      if (handler.onMousedown) {
+        map.off("mousedown", handler.onMousedown);
+      }
+      if (handler.onMouseup) {
+        map.off("mouseup", handler.onMouseup);
+      }
+      if (handler.onMousemove) {
+        map.off("mousemove", handler.onMousemove);
+      }
+    }
+  }
+
+  watch(active, (nowActive: boolean) => {
+    const mMap = map.value;
+    if (mMap !== null) {
+      updateListeners(mMap, nowActive);
+    }
+  });
+
+  // If we're going to take in the map as a ref,
+  // we might as well update if its value does
+  watch(map, (newMap: Map | null) => {
+    if (newMap !== null) {
+      updateListeners(newMap, active.value);
+    }
+  });
+
+  onUnmounted(() => {
+    // The map will probably be destroyed along with the component using this composable
+    // But if not, we should remove handlers
+    const mMap = map.value;
+    if (mMap !== null && active.value) {
+      updateListeners(mMap, false);
+    }
+  });
+
+  return {
+    active,
+    selectionInfo: handler.selectionInfo,
+  };
+
+}

--- a/src/composables/maplibre/usePointSelection.ts
+++ b/src/composables/maplibre/usePointSelection.ts
@@ -13,7 +13,7 @@ export function usePointSelection(
     selectionInfo: ref<PointSelectionInfo | null>(null),
 
     onMouseup(event: MapMouseEvent) {
-      this.selectionInfo.value = {
+      handler.selectionInfo.value = {
         x: event.lngLat.lng,
         y: event.lngLat.lat,
       };

--- a/src/composables/maplibre/usePointSelection.ts
+++ b/src/composables/maplibre/usePointSelection.ts
@@ -1,22 +1,21 @@
 import { ref, type Ref } from "vue";
-import { type LeafletMouseEvent, Map } from "leaflet";
+import { Map, MapMouseEvent } from "maplibre-gl";
 
-import { PointSelectionInfo, SelectionHandler } from "../../types";
+import type { PointSelectionInfo, SelectionHandler } from "../../types";
 import { baseUseSelection } from "./baseUseSelection";
 
 export function usePointSelection(
   map: Ref<Map | null>,
   startActive: boolean = false,
 ) {
-
-  const handler: SelectionHandler<LeafletMouseEvent, PointSelectionInfo> = {
-
+  
+  const handler: SelectionHandler<MapMouseEvent, PointSelectionInfo> = {
     selectionInfo: ref<PointSelectionInfo | null>(null),
 
-    onMouseup(event: LeafletMouseEvent) {
+    onMouseup(event: MapMouseEvent) {
       this.selectionInfo.value = {
-        x: event.latlng.lng,
-        y: event.latlng.lat,
+        x: event.lngLat.lng,
+        y: event.lngLat.lat,
       };
     },
   };

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -1,9 +1,10 @@
-import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
+import { ref, type Ref } from "vue";
 import { GeoJSONSource, LngLat, Map, MapMouseEvent } from "maplibre-gl";
 import { v4 } from "uuid";
 
-import type { RectangleSelectionInfo } from "../../types";
+import type { RectangleSelectionInfo, SelectionHandler } from "../../types";
 import type { LayerType } from "./utils";
+import { baseUseSelection } from "./baseUseSelection";
 
 
 export function useRectangleSelection(
@@ -16,163 +17,116 @@ export function useRectangleSelection(
   let rectangleLayer: LayerType | undefined = undefined;
   let startCoords: LngLat | null = null;
   let geoJson: GeoJSON.FeatureCollection;
-  const selectionInfo = ref<RectangleSelectionInfo | null>(null);
-  const active = ref(startActive);
   const uuid = v4();
 
-  onMounted(() => {
-    const mMap = map.value;
-    if (active.value && mMap) {
-      updateListeners(mMap, active.value);
-    }
-  });
+  const handler: SelectionHandler<MapMouseEvent, RectangleSelectionInfo> = {
 
-  function onMousedown(event: MapMouseEvent) {
-    const mMap = map.value;
-    if (!mMap) {
-      return;
-    }
+    selectionInfo: ref<RectangleSelectionInfo | null>(null),
 
-    startCoords = event.lngLat;
-    geoJson = {
-      type: "FeatureCollection",
-      features: [{
-        type: "Feature",
+    onMousedown(event: MapMouseEvent) {
+      const mMap = map.value;
+      if (!mMap) {
+        return;
+      }
+
+      startCoords = event.lngLat;
+      geoJson = {
+        type: "FeatureCollection",
+        features: [{
+          type: "Feature",
+          geometry: {
+            type: "Polygon",
+            coordinates: [[
+              [startCoords.lng, startCoords.lat],
+              [startCoords.lng, startCoords.lat],
+              [startCoords.lng, startCoords.lat],
+              [startCoords.lng, startCoords.lat],
+            ]],
+          },
+          properties: {},
+        }],
+      };
+
+      mMap.addSource(uuid, {
+        type: "geojson",
+        data: geoJson,
+      });
+
+      const source = mMap.getSource(uuid);
+      if (!source) {
+        return;
+      }
+
+      rectangleSource = source as GeoJSONSource;
+
+      mMap.addLayer({
+        id: uuid,
+        type: "line",
+        source: uuid,
+        paint: {
+          "line-color": interactColor,
+          "line-width": 2,
+          "line-dasharray": [2, 1],
+        }
+      });
+
+      const layer = mMap.getLayer(uuid);
+      if (layer) {
+        rectangleLayer = layer;
+      }
+    },
+
+    onMouseup(event: MapMouseEvent) {
+      const mMap = map.value;
+      if (!mMap || startCoords === null) {
+        return;
+      }
+
+      const eventCoords = event.lngLat;
+      this.selectionInfo.value = {
+        xmin: startCoords.lng,
+        ymin: startCoords.lat,
+        xmax: eventCoords.lng,
+        ymax: eventCoords.lat,
+      };
+
+      if (rectangleLayer) {
+        mMap.removeLayer(rectangleLayer.id);
+      }
+      if (rectangleSource) {
+        mMap.removeSource(rectangleSource.id);
+      }
+      startCoords = null;
+
+    },
+
+    onMousemove(event: MapMouseEvent) {
+      const mMap = map.value;
+      if (!mMap || (startCoords === null) || (!geoJson)) {
+        return;
+      }
+
+      const eventCoords = event.lngLat;
+      const coordinates = [[
+        [startCoords.lng, startCoords.lat],
+        [eventCoords.lng, startCoords.lat],
+        [eventCoords.lng, eventCoords.lat],
+        [startCoords.lng, eventCoords.lat],
+        [startCoords.lng, startCoords.lat],
+      ]];
+
+      geoJson.features[0] = {
+        ...geoJson.features[0],
         geometry: {
           type: "Polygon",
-          coordinates: [[
-            [startCoords.lng, startCoords.lat],
-            [startCoords.lng, startCoords.lat],
-            [startCoords.lng, startCoords.lat],
-            [startCoords.lng, startCoords.lat],
-          ]],
-        },
-        properties: {},
-      }],
-    };
+          coordinates,
+        }
+      };
 
-    mMap.addSource(uuid, {
-      type: "geojson",
-      data: geoJson,
-    });
-
-    const source = mMap.getSource(uuid);
-    if (!source) {
-      return;
+      rectangleSource?.setData(geoJson);
     }
-
-    rectangleSource = source as GeoJSONSource;
-
-    mMap.addLayer({
-      id: uuid,
-      type: "line",
-      source: uuid,
-      paint: {
-        "line-color": interactColor,
-        "line-width": 2,
-        "line-dasharray": [2, 1],
-      }
-    });
-
-    const layer = mMap.getLayer(uuid);
-    if (layer) {
-      rectangleLayer = layer;
-    }
-  }
-
-  function onMouseup(event: MapMouseEvent) {
-    const mMap = map.value;
-    if (!mMap || startCoords === null) {
-      return;
-    }
-
-    const eventCoords = event.lngLat;
-    selectionInfo.value = {
-      xmin: startCoords.lng,
-      ymin: startCoords.lat,
-      xmax: eventCoords.lng,
-      ymax: eventCoords.lat,
-    };
-
-    if (rectangleLayer) {
-      mMap.removeLayer(rectangleLayer.id);
-    }
-    if (rectangleSource) {
-      mMap.removeSource(rectangleSource.id);
-    }
-    startCoords = null;
-
-  }
-
-  function onMousemove(event: MapMouseEvent) {
-    const mMap = map.value;
-    if (!mMap || (startCoords === null) || (!geoJson)) {
-      return;
-    }
-
-    const eventCoords = event.lngLat;
-    const coordinates = [[
-      [startCoords.lng, startCoords.lat],
-      [eventCoords.lng, startCoords.lat],
-      [eventCoords.lng, eventCoords.lat],
-      [startCoords.lng, eventCoords.lat],
-      [startCoords.lng, startCoords.lat],
-    ]];
-
-    geoJson.features[0] = {
-      ...geoJson.features[0],
-      geometry: {
-        type: "Polygon",
-        coordinates,
-      }
-    };
-
-    rectangleSource?.setData(geoJson);
-  }
-
-  function updateListeners(map: Map, active: boolean) {
-    if (active) {
-      map.dragPan.disable();
-      map.scrollZoom.disable();
-      map.on("mousedown", onMousedown);
-      map.on("mouseup", onMouseup);
-      map.on("mousemove", onMousemove);
-    } else {
-      map.dragPan.enable();
-      map.scrollZoom.enable();
-      map.off("mousedown", onMousedown);
-      map.off("mouseup", onMouseup);
-      map.off("mousemove", onMousemove);
-    }
-  }
-
-  watch(active, (nowActive: boolean) => {
-    const mMap = map.value;
-    if (mMap !== null) {
-      updateListeners(mMap, nowActive);
-    }
-  });
-
-  // If we're going to take in the map as a ref,
-  // we might as well update if its value does
-  watch(map, (newMap: Map | null) => {
-    if (newMap !== null) {
-      updateListeners(newMap, active.value);
-    }
-  });
-
-  onUnmounted(() => {
-    // The map will probably be destroyed along with the component using this composable
-    // But if not, we should remove handlers
-    const mMap = map.value;
-    if (mMap !== null && active.value) {
-      updateListeners(mMap, false);
-    }
-  });
-
-  return {
-    selectionInfo,
-    active,
   };
+
+  return baseUseSelection({ map, handler, startActive });
 
 }

--- a/src/composables/maplibre/useRectangleSelection.ts
+++ b/src/composables/maplibre/useRectangleSelection.ts
@@ -83,7 +83,7 @@ export function useRectangleSelection(
       }
 
       const eventCoords = event.lngLat;
-      this.selectionInfo.value = {
+      handler.selectionInfo.value = {
         xmin: startCoords.lng,
         ymin: startCoords.lat,
         xmax: eventCoords.lng,

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,11 @@ export interface RectangleSelectionInfo {
   ymax: number;
 }
 
+export interface PointSelectionInfo {
+  x: number;
+  y: number;
+}
+
 export type AggValue = {
   value: number | null;
   date: Date;

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,3 +140,18 @@ export interface RectangleSelection<T extends MappingBackends> {
   errors?: Record<number, DataPointError>;
   timeRange?: MillisecondRange | MillisecondRange[];
 }
+
+export interface SelectionHandler<EventType, SelectionInfo> {
+  selectionInfo: Ref<SelectionInfo | null>;
+  onMouseup?: (event: EventType) => void;
+  onMousedown?: (event: EventType) => void;
+  onMousemove?: (event: EventType) => void;
+}
+
+export interface UseSelectionOptions<MapType, EventType, SelectionInfo> {
+  map: Ref<MapType | null>;
+  handler: SelectionHandler<EventType, SelectionInfo>;
+  startActive?: boolean;
+}
+
+


### PR DESCRIPTION
This PR adds a point selection tool, similar to the rectangle selection tool added in #1. Additionally, since there is a lot of generic code for these selection tools, I've refactored to have a "base" composable for each mapping backend. The rectangle and point selection functionality each define a "handler" to define what happens on mouse events, and the "base" composable handles things like listening for map/active changes and lifecycle hooks, and attaching/detaching handlers when necessary.

@johnarban I didn't want to mess with anything that you were doing so this isn't actually connected to the main app, but locally I tried making it active and logging results and it (and rectangle selection) seemed to work fine.