### PR TITLE
Simplify workflow for now

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,8 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
-      - dev
+      main
 
 jobs:
   build:
@@ -59,44 +58,10 @@ jobs:
         with:
           cmd: cat package.json | jq -r '.draft // false'
 
-      - name: Create folder for deployment
-        run: |
-          mkdir deployment
-          mkdir deployment/dev
-
-      - name: Move current build to deployment
-        id: prepare
-        env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
-        run: |
-          echo "Current branch: ${BRANCH}"
-          [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
-          echo "Folder to use: ${folder}"
-          mv dist/* deployment/${folder}
-          [[ "$BRANCH" == "dev" ]] && other="main" || other="dev"
-          echo "Other branch: ${other}"
-          echo "other=${other}" >> "$GITHUB_OUTPUT"
-
-      - name: Check out the other branch
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.prepare.outputs.other }}
-          path: other
-
-      - name: Build other branch and move to deployment
-        env:
-          BRANCH: ${{ steps.prepare.outputs.other }}
-        run: |
-          cd other
-          yarn install
-          yarn build
-          [[ "$BRANCH" == "dev" ]] && folder="dev" || folder="."
-          mv dist/* ../deployment/${folder}
-
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: ${{ steps.draft.outputs.value }} == 'false'
         with:
           branch: gh-pages
-          folder: deployment 
+          folder: dist
           ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
This repository is using the same workflow file as `tempo-lite`, but deployments are failing because it's looking for a `dev` branch - this is relevant for deployment a development version of `tempo-lite`, but we don't have that here yet. So this PR modifies things to use the simpler older workflow - if/when we have a dev version that we want live, we can change it back.