### PR TITLE
Fix issue with time range selection dropdown

### DIFF
--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -35,16 +35,19 @@
       <!-- Time Range Picker: offer Effective (current day/custom) and any active custom ranges -->
       <v-select
         :items="timeRanges"
-        :model-value="draftUserSelection.timeRange"
-        @update:model-value="setDraftSelectionTimeRange($event)"
+        v-model="selectedTimeRange"
         label="Time Range"
         :disabled="disabled?.timeRange"
         item-title="name"
-        item-value="range"
         density="compact"
         hide-details
         variant="outlined"
-      />
+        return-object
+        >
+        <template #selection="{ item }">
+          {{ item.title }}
+        </template>
+      </v-select>
 
       <v-progress-linear :model-value="creationProgress.percent" height="6" color="primary" rounded></v-progress-linear>
 
@@ -67,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { v4 } from "uuid";
 
 import type { MappingBackends, RectangleSelection, TimeRange, UserSelection } from "../types";
@@ -77,6 +80,7 @@ import { atleast1d } from "../utils/atleast1d";
 import { formatTimeRange } from "../utils/timeRange";
 
 let selectionCount = 0; // for naming selections
+const selectedTimeRange = ref<TimeRange | null>(null);
 
 interface SelectionComposerProps {
   backend: MappingBackends;
@@ -119,6 +123,7 @@ function setDraftSelectionMolecule(molecule: MoleculeType | null) {
 }
 
 function setDraftSelectionTimeRange(range: MillisecondRange | MillisecondRange[] | null) {
+  console.log("SETTING DRAFT SELECTION");
   draftUserSelection.value.timeRange = range || null;
 }
 
@@ -151,5 +156,10 @@ function composeSelection(): UserSelection | null {
 
 function reset() {
   draftUserSelection.value = { region: null, timeRange: null, molecule: null };
+  selectedTimeRange.value = null;
 }
+
+watch(selectedTimeRange, (timeRange: TimeRange | null) => {
+  setDraftSelectionTimeRange(timeRange?.range ?? null);
+});
 </script>

--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -44,9 +44,6 @@
         variant="outlined"
         return-object
         >
-        <template #selection="{ item }">
-          {{ item.title }}
-        </template>
       </v-select>
 
       <v-progress-linear :model-value="creationProgress.percent" height="6" color="primary" rounded></v-progress-linear>
@@ -123,7 +120,6 @@ function setDraftSelectionMolecule(molecule: MoleculeType | null) {
 }
 
 function setDraftSelectionTimeRange(range: MillisecondRange | MillisecondRange[] | null) {
-  console.log("SETTING DRAFT SELECTION");
   draftUserSelection.value.timeRange = range || null;
 }
 


### PR DESCRIPTION
This PR fixes the issue that we were seeing with the time range selector display.

It feels like there should be a more elegant way to do this without an intermediate reactive, but the Vuetify docs don't actually offer a great example of this - the one that they do uses `return-object`, which somewhat obscures what we would need to do here. But this works totally fine.