### PR TITLE
Update timeseries graph bounds

### DIFF
--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -135,7 +135,7 @@ function renderPlot() {
     }
   });
 
-  const paddingFactor = 1.2;
+  const paddingFactor = 1.1;
   const axisMin = Math.min(0, paddingFactor * min);
   const axisMax = Math.max(1, paddingFactor * max);
   const layout = {

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -53,7 +53,6 @@ function renderPlot() {
     return;
   }
 
-  let min = 0;
   let max = 0;
   props.data.forEach(data => {
     const samples = data.samples;
@@ -71,7 +70,6 @@ function renderPlot() {
         dataV.push(point.value);
       }
     });
-    min = Math.min(min, Math.min(...dataV.filter((v): v is number => v !== null)));
     max = Math.max(max, Math.max(...dataV.filter((v): v is number => v !== null)));
 
     const legendGroup = v4();
@@ -104,7 +102,6 @@ function renderPlot() {
         const valueHigher = value + upper;
         const low = Math.min(valueLower, valueHigher);
         const high = Math.max(valueLower, valueHigher);
-        min = Math.min(min, low);
         max = Math.max(max, high);
         lowerY.push(low);
         upperY.push(high);
@@ -136,13 +133,12 @@ function renderPlot() {
   });
 
   const paddingFactor = 1.1;
-  const axisMin = Math.min(0, paddingFactor * min);
   const axisMax = Math.max(1, paddingFactor * max);
   const layout = {
     width: 600,
     height: 400,
     yaxis: {
-      range: [axisMin, axisMax],
+      range: [0, axisMax],
     }
   };
 

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -138,6 +138,7 @@ function renderPlot() {
     width: 600,
     height: 400,
     yaxis: {
+      title: { text: "Molecules / cm<sup>2</sup>" },
       range: [0, axisMax],
     }
   };

--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -53,6 +53,7 @@ function renderPlot() {
     return;
   }
 
+  let min = 0;
   let max = 0;
   props.data.forEach(data => {
     const samples = data.samples;
@@ -70,6 +71,7 @@ function renderPlot() {
         dataV.push(point.value);
       }
     });
+    min = Math.min(min, Math.min(...dataV.filter((v): v is number => v !== null)));
     max = Math.max(max, Math.max(...dataV.filter((v): v is number => v !== null)));
 
     const legendGroup = v4();
@@ -100,8 +102,12 @@ function renderPlot() {
         const { lower, upper } = errs;
         const valueLower = value - lower;
         const valueHigher = value + upper;
-        lowerY.push(Math.min(valueLower, valueHigher));
-        upperY.push(Math.max(valueLower, valueHigher));
+        const low = Math.min(valueLower, valueHigher);
+        const high = Math.max(valueLower, valueHigher);
+        min = Math.min(min, low);
+        max = Math.max(max, high);
+        lowerY.push(low);
+        upperY.push(high);
       });
 
       plotlyData.push({
@@ -129,11 +135,14 @@ function renderPlot() {
     }
   });
 
+  const paddingFactor = 1.2;
+  const axisMin = Math.min(0, paddingFactor * min);
+  const axisMax = Math.max(1, paddingFactor * max);
   const layout = {
     width: 600,
     height: 400,
     yaxis: {
-      range: [0, 1.2 * max],
+      range: [axisMin, axisMax],
     }
   };
 


### PR DESCRIPTION
Currently we only use the timeseries values themselves when calculating the bounds for the timeseries graph. This PR updates the graph component to use the size of error bands as well when determining the bounds.