### PR TITLE
Don't reset selection composer after a selection is created

### DIFF
--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -145,8 +145,6 @@ function composeSelection(): UserSelection | null {
     name: `Selection ${selectionCount}`
   };
   emit("create", sel);
-
-  reset();
   return sel;
 }
 


### PR DESCRIPTION
This PR updates the selection composer to not reset its dropdowns after a selection is created. This way, when a user goes to make a new selection, they'll be starting with the parameters of their previous selection.