### PR TITLE
Monthly average UI

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1546,7 +1546,8 @@ function handleEsriTimeSelected(timestamp:number, _index: number) {
   if (idx >= 0) {
     timeIndex.value = idx;
   }
-  singleDateSelected.value = new Date(timestamp);
+  // We may need something like this when we get back the monthly average service.
+  //singleDateSelected.value = new Date(timestamp);
 }
 
 watch(whichMolecule, (newMolecule) => {

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -566,10 +566,12 @@
                   <!-- time chips to select time specifically for esri times -->
                   <time-chips
                     v-if="whichMolecule.toLowerCase().includes('month')"
-                    :timestamps="esriTimesteps"
+                    :timestamps="esriTimesteps.slice(minIndex, maxIndex + 1)"
                     @select="handleEsriTimeSelected($event.value, $event.index)"
-                    use-utc
-                    date-only
+                    :selected-index="timeIndex - minIndex"
+                    :use-utc="whichMolecule.toLowerCase().includes('month')"
+                    :date-only="whichMolecule.toLowerCase().includes('month')"
+                    :hour-only="!whichMolecule.toLowerCase().includes('month')"
                   />
                 </v-radio-group>
               </div>        
@@ -1497,6 +1499,7 @@ const mapTitle = computed(() => {
 });
 
 import { stretches, colorramps } from "./esri/ImageLayerConfig";
+import { min } from "date-fns";
 
 const colorbarOptions = {
   'no2': {stretch: stretches['NO2_Troposphere'], cbarScale: 1e14, colormap: colorramps['NO2_Troposphere'] + '_r', label:'NO<sub>2</sub>&nbsp;&nbsp;'},

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -568,7 +568,6 @@
                     v-if="whichMolecule.toLowerCase().includes('month')"
                     :timestamps="esriTimesteps"
                     @select="handleEsriTimeSelected($event.value, $event.index)"
-                    reverse
                     use-utc
                     date-only
                   />

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1499,7 +1499,6 @@ const mapTitle = computed(() => {
 });
 
 import { stretches, colorramps } from "./esri/ImageLayerConfig";
-import { min } from "date-fns";
 
 const colorbarOptions = {
   'no2': {stretch: stretches['NO2_Troposphere'], cbarScale: 1e14, colormap: colorramps['NO2_Troposphere'] + '_r', label:'NO<sub>2</sub>&nbsp;&nbsp;'},

--- a/src/components/TimeChips.vue
+++ b/src/components/TimeChips.vue
@@ -106,8 +106,11 @@ const handleChipClick = (value: number, index: number) => {
 }
 
 .chips-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  /* display: grid; */
+  /* grid-template-columns: repeat(5, 1fr); */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
   gap: 8px;
   max-height: 276px;
   overflow-y: auto;
@@ -116,10 +119,11 @@ const handleChipClick = (value: number, index: number) => {
 
 
 .time-chip {
+  flex-basis: 15%;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 70px;
+  height: fit-content;
   padding: 8px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -138,7 +142,6 @@ const handleChipClick = (value: number, index: number) => {
 }
 
 .time-chip:active {
-  transform: translateY(0);
   background: #8cc5ff;
 }
 

--- a/src/composables/useUniqueTimeSelection.ts
+++ b/src/composables/useUniqueTimeSelection.ts
@@ -14,7 +14,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
   const maxIndex = ref<number>(0);
   
   const mode = ref<'single' | 'all'>('single');
-  const defaultInit = ref<'first' | 'last'>('first');
+  const initialTimeSelection = ref<'first' | 'last'>('first');
 
   function getOneDaysTimestamps(date: Date) {
     if (isBad(date)) {
@@ -49,7 +49,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     if (mod.length > 0) {
       minIndex.value = mod[0].idx;
       maxIndex.value = mod[mod.length - 1].idx;
-      timeIndex.value = defaultInit.value === 'first' ? minIndex.value : maxIndex.value;
+      timeIndex.value = initialTimeSelection.value === 'first' ? minIndex.value : maxIndex.value;
     } else {
       console.warn("No timestamps found for the given date.");
     }
@@ -154,7 +154,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     minIndex,
     uniqueDays,
     mode,
-    defaultInit,
+    initialTimeSelection,
     uniqueDaysIndex,
     setNearestDate,
     getUniqueDayIndex,

--- a/src/composables/useUniqueTimeSelection.ts
+++ b/src/composables/useUniqueTimeSelection.ts
@@ -14,6 +14,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
   const maxIndex = ref<number>(0);
   
   const mode = ref<'single' | 'all'>('single');
+  const defaultInit = ref<'first' | 'last'>('first');
 
   function getOneDaysTimestamps(date: Date) {
     if (isBad(date)) {
@@ -48,7 +49,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     if (mod.length > 0) {
       minIndex.value = mod[0].idx;
       maxIndex.value = mod[mod.length - 1].idx;
-      timeIndex.value = minIndex.value;
+      timeIndex.value = defaultInit.value === 'first' ? minIndex.value : maxIndex.value;
     } else {
       console.warn("No timestamps found for the given date.");
     }
@@ -153,6 +154,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     minIndex,
     uniqueDays,
     mode,
+    defaultInit,
     uniqueDaysIndex,
     setNearestDate,
     getUniqueDayIndex,

--- a/src/composables/useUniqueTimeSelection.ts
+++ b/src/composables/useUniqueTimeSelection.ts
@@ -12,6 +12,8 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
   const singleDateSelected = ref<Date>(new Date());
   const minIndex = ref<number>(0);
   const maxIndex = ref<number>(0);
+  
+  const mode = ref<'single' | 'all'>('single');
 
   function getOneDaysTimestamps(date: Date) {
     if (isBad(date)) {
@@ -25,13 +27,24 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     });
     return mod;
   }
+  
+  function getAllDaysTimestamps(date: Date) {
+    if (isBad(date)) {
+      return [];
+    }
+    // const mod = [] as {ts:number, idx: number}[];
+    // timestamps.value.forEach((ts, idx) => {
+    //   mod.push({ ts, idx });
+    // });
+    return timestamps.value.map((ts, idx) => ({ ts, idx }));
+  }
 
   function setNearestDate(date: number | null) {
     if (date == null) {
       return;
     }
 
-    const mod = getOneDaysTimestamps(new Date(date));
+    const mod = mode.value === 'single' ? getOneDaysTimestamps(new Date(date)) : getAllDaysTimestamps(new Date(date));
     if (mod.length > 0) {
       minIndex.value = mod[0].idx;
       maxIndex.value = mod[mod.length - 1].idx;
@@ -110,6 +123,26 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
   watch(singleDateSelected, (value) => {
     setNearestDate(value.getTime());
   });
+  
+  watch(mode, () => {
+    setNearestDate(singleDateSelected.value.getTime());
+  });
+
+  watch(timestamps, (newTimestamps) => {
+    if (newTimestamps.length === 0) {
+      timeIndex.value = 0;
+      minIndex.value = 0;
+      maxIndex.value = 0;
+      return;
+    }
+    // Reset to first date if current date is out of range
+    if (timeIndex.value >= newTimestamps.length) {
+      timeIndex.value = 0;
+      singleDateSelected.value = new Date(newTimestamps[0]);
+    } else {
+      setNearestDate(singleDateSelected.value.getTime());
+    }
+  }, { immediate: true });
 
   return {
     timeIndex,
@@ -119,6 +152,7 @@ export const useUniqueTimeSelection = (timestamps: Ref<number[]>) => {
     maxIndex,
     minIndex,
     uniqueDays,
+    mode,
     uniqueDaysIndex,
     setNearestDate,
     getUniqueDayIndex,


### PR DESCRIPTION
Fix #38 by
- allowing use to select the full range for the time-slider using the new `mode` exported from`useUniqueTimeSelection`. 
- Allow the user to start the time slider at the first or last value using the new `initialTimeSelection` exported from `useUniqueTimeSelection`
- reveres order to oldest date is first

This also adjusts the styling to prevent horizontal scrolling (use flex instead of grid) and makes the chips adjust to the size of the content. 