### PR TITLE
Fix region editing

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1969,7 +1969,7 @@ function editRegionName(region: UnifiedRegionType) {
   // Set the region to edit
   const existing = (regions.value as UnifiedRegionType[]).find(r => r.id === region.id);
   if (!existing) {
-    console.error(`Selection with ID ${region.id} not found.`);
+    console.error(`Region with ID ${region.id} not found.`);
     return;
   }
   regionBeingEdited.value = region;
@@ -1979,6 +1979,7 @@ function editRegionName(region: UnifiedRegionType) {
 function setRegionName(region: UnifiedRegionType, newName: string) {
   if (newName.trim() === '') {
     console.error("Region name cannot be empty.");
+    regionBeingEdited.value = null;
     return;
   }
   const existing = (regions.value as UnifiedRegionType[]).find(r => r.name === newName && r.id !== region.id);
@@ -1988,6 +1989,7 @@ function setRegionName(region: UnifiedRegionType, newName: string) {
   }
   region.name = newName;
   console.log(`Renamed ${region.geometryType} region to: ${newName}`);
+  regionBeingEdited.value = null;
 }
 
 function deleteRegion(region: UnifiedRegionType) {
@@ -2563,6 +2565,7 @@ function handleSelectionRegionEdit(info: RectangleSelectionInfo) {
   console.log(`Updated existing selection: ${currentSelection.name} (time range unchanged)`);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function handleRegionEdit(info: RectangleSelectionInfo | PointSelectionInfo) {
   if (regionBeingEdited.value) {
     regionBeingEdited.value.geometryInfo = info;
@@ -2591,7 +2594,8 @@ watch(rectangleInfo, (info: RectangleSelectionInfo | null) => {
     createDraftSelection(info, 'rectangle');
     rectangleSelectionActive.value = false;
   } else {
-    handleRegionEdit(info);
+    return;
+    // handleRegionEdit(info);
   }
   
   // do not permit editing a region on a selection
@@ -2610,7 +2614,8 @@ watch(pointInfo, (info: PointSelectionInfo | null) => {
     createDraftSelection(info, 'point');
     pointSelectionActive.value = false;
   } else {
-    handleRegionEdit(info);
+    return;
+    // handleRegionEdit(info);
   }
 });
 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -2585,8 +2585,22 @@ function handleRegionEdit(info: RectangleSelectionInfo | PointSelectionInfo) {
   regionBeingEdited.value = null;
 }
 
+function rectangleIsDegenerate(info: RectangleSelectionInfo): boolean {
+  return info.xmax === info.xmin || info.ymax === info.ymin;
+}
 watch(rectangleInfo, (info: RectangleSelectionInfo | null) => {
   if (info === null || map.value === null) {
+    rectangleSelectionActive.value = false;
+    return;
+  }
+  if (rectangleIsDegenerate(info)) {
+    // make it a point selection instead
+    // TODO: only implement when we have a solution to only do this on a double-click
+    // pointInfo.value = {
+    //   x: info.xmin,
+    //   y: info.ymin
+    // };
+    rectangleSelectionActive.value = false;
     return;
   }
   const canCreate = (selection.value === null || selectedIndex.value === null) && !regionBeingEdited.value;
@@ -2607,6 +2621,7 @@ watch(rectangleInfo, (info: RectangleSelectionInfo | null) => {
 // Add watcher for point selection
 watch(pointInfo, (info: PointSelectionInfo | null) => {
   if (info === null || map.value === null) {
+    pointSelectionActive.value = false;
     return;
   }
   const canCreate = (selection.value === null || selectedIndex.value === null) && !regionBeingEdited.value;

--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -191,6 +191,16 @@ function reset() {
 watch(selectedTimeRange, (timeRange: TimeRange | null) => {
   setDraftSelectionTimeRange(timeRange?.range ?? null);
 });
+
+// just watch the id's. using a 'deep' watch caused a significant performance hit
+watch(() => props.regions.map(r => r.id), (newRegions) => {
+  if (draftUserSelection.value.region) {
+    const exists = newRegions.find(rid => rid === draftUserSelection.value.region?.id);
+    if (!exists) {
+      draftUserSelection.value.region = null;
+    }
+  }
+});
 </script>
 
 <style scoped>

--- a/src/composables/maplibre/baseUseSelection.ts
+++ b/src/composables/maplibre/baseUseSelection.ts
@@ -49,6 +49,7 @@ export function baseUseSelection<SelectionInfo>(
     const mMap = map.value;
     if (mMap !== null) {
       updateListeners(mMap, nowActive);
+      mMap.getCanvas().style.cursor = nowActive ? 'crosshair' : '';
     }
   });
 


### PR DESCRIPTION
This PR handles many of the issues from #41. This
- fixes the bug where edit name enabled region error
- disables altering region editing (there is no ui path for this anyway)
- clears the selection when a region is deleted.
- eliminate 0 size regions