### PR TITLE
Updates to dataset selection UI

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -812,7 +812,6 @@
                     <v-list-item
                       v-bind="props"
                       class="selection-item"
-                      :title="sel.name"
                       :style="{ 'background-color': `rgb(from ${sel.region.color} r g b / 0.35)` }"
                       :ripple="touchscreen"
                       @click="() => {
@@ -823,6 +822,7 @@
                       lines="two"
                     >
                       <template #subtitle>
+                        <v-chip>{{ sel.region.name }}</v-chip>
                         <v-chip>{{ moleculeName(sel.molecule) }}</v-chip>
                         <v-chip v-if="sel.timeRange" class="text-caption">
                           {{ sel.timeRange.description }}
@@ -856,7 +856,7 @@
                                 <v-btn
                                   v-bind="props"
                                   size="x-small"
-                                  :loading="loadingPointSample === sel.name"
+                                  :loading="loadingPointSample === sel.id"
                                   icon="mdi-image-filter-center-focus"
                                   variant="plain"
                                   @click="() => fetchCenterPointDataForSelection(sel)"
@@ -994,35 +994,6 @@
             :show-errors="showErrorBands"
           />
         </cds-dialog>
-        
-        
-        <v-dialog
-          v-model="showEditSelectionNameDialog"
-          >
-          <v-card
-            class="mx-auto px-3 py-2"
-            min-width="300px"
-            width="50%"
-          >
-            <v-card-title>New Name</v-card-title>
-            <v-text-field
-              label="Selection Name"
-              hide-details
-              dense
-              @update:model-value="(val: string) => {
-                setSelectionName(selection as UserSelectionType, val);
-              }"
-            ></v-text-field>
-            <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn
-                :color="accentColor"
-                variant="flat"
-                @click="showEditSelectionNameDialog = false"
-              >Done</v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
         
         <v-dialog
           v-model="showEditRegionNameDialog"
@@ -1663,7 +1634,7 @@ function setSelection(sel: UserSelectionType | null) {
   const idx = selections.value.findIndex(s => s.id === sel.id);
   if (idx == -1) {
     // must already be in selections, so throw an error if that is not true
-    throw new Error(`Selection with ID ${sel.id} and name ${sel.name} not found in selections.`);
+    throw new Error(`Selection with ID ${sel.id} not found in selections.`);
   }
   selection.value = selections.value[idx];
   selectedIndex.value = idx;
@@ -1843,20 +1814,6 @@ function editSelectionName(sel: UserSelectionType | null) {
   
   // Open dialog for renaming
   showEditSelectionNameDialog.value = true;
-}
-
-function setSelectionName(sel: UserSelectionType, newName: string) {
-  if (newName.trim() === '') {
-    console.error("Selection name cannot be empty.");
-    return;
-  }
-  const existing = selections.value.find(s => s.name === newName && s.id !== sel.id);
-  if (existing) {
-    console.error(`A selection with the name "${newName}" already exists.`);
-    return;
-  }
-  sel.name = newName;
-  console.log(`Renamed selection to: ${newName}`);
 }
 
 function createNewSelection(geometryType: 'rectangle' | 'point') {

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1611,8 +1611,8 @@ const graphSelectionTitle = computed(() => {
     return '';
   }
   const molecule = graphSelection.value.molecule;
-  const title = MOLECULE_OPTIONS.find(m => m.value === molecule)?.title || '';
-  return `${title} Time Series for ${graphSelection.value.name}`;
+  const molTitle = MOLECULE_OPTIONS.find(m => m.value === molecule)?.title || '';
+  return `${molTitle} Time Series for ${sel.region.name}`;
 });
 
 const showNO2Graph = ref(false);

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -850,21 +850,36 @@
                               </span>
                             </template>
                           </v-progress-linear>
-                          <v-tooltip
-                            text="Failure info"
-                            location="top"
-                            v-if="!(sel.loading || sel.samples)"
-                          >
-                            <template #activator="{ props }">
-                              <v-btn
-                                v-bind="props"
-                                size="x-small"
-                                icon="mdi-help-circle"
-                                variant="plain"
-                                @click="() => sampleErrorID = sel.id"
-                              ></v-btn>
-                            </template>
-                          </v-tooltip>
+                          <div v-if="!(sel.loading || sel.samples)">
+                            <v-tooltip
+                              text="Failure info"
+                              location="top"
+                            >
+                              <template #activator="{ props }">
+                                <v-btn
+                                  v-bind="props"
+                                  size="x-small"
+                                  icon="mdi-help-circle"
+                                  variant="plain"
+                                  @click="() => sampleErrorID = sel.id"
+                                ></v-btn>
+                              </template>
+                            </v-tooltip>
+                            <v-tooltip
+                              text="Remove selection"
+                              location="top"
+                            >
+                              <template #activator="{ props }">
+                                <v-btn
+                                  v-bind="props"
+                                  size="x-small"
+                                  icon="mdi-trash-can"
+                                  variant="plain"
+                                  @click="() => deleteSelection(sel)"
+                                ></v-btn>
+                              </template>
+                            </v-tooltip>
+                          </div>
                         </div>
 
                         <v-expand-transition>
@@ -3697,7 +3712,7 @@ canvas.maplibregl-canvas {
 }
 
 .dataset-loading-failed {
-  width: 80%;
+  width: 70%;
   max-width: calc(100% - 32px);
 }
 </style>

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -819,17 +819,20 @@
                           openSelection = (openSelection == sel.id) ? null : sel.id;
                         }
                       }"
-                      lines="three"
+                      lines="two"
                     >
                       <template #default>
-                        <v-row>
+                        <div>
                           <v-chip size="small">{{ sel.region.name }}</v-chip>
                           <v-chip size="small">{{ moleculeName(sel.molecule) }}</v-chip>
                           <v-chip v-if="sel.timeRange" size="small" class="text-caption">
                             {{ sel.timeRange.description }}
                           </v-chip>
-                        </v-row>
-                        <v-row class="dataset-loading">
+                        </div>
+                        <div
+                          v-if="sel.loading || !sel.samples"
+                          class="dataset-loading"
+                        >
                           <v-progress-linear
                             :class="['dataset-loading-progress', !(sel.loading && sel.samples) ? 'dataset-loading-failed' : '']"
                             :active="sel.loading || !sel.samples"
@@ -838,7 +841,8 @@
                             :value="!sel.loading ? 100 : 0"
                             :striped="!sel.loading"
                             bottom
-                            height="40"
+                            rounded
+                            height="20"
                           >
                             <template #default>
                               <span class="text-subtitle-2">
@@ -861,7 +865,7 @@
                               ></v-btn>
                             </template>
                           </v-tooltip>
-                        </v-row>
+                        </div>
 
                         <v-expand-transition>
                           <div
@@ -946,18 +950,24 @@
                         <v-dialog
                           :model-value="sampleErrorID !== null"
                           max-width="50%"
-                          height="250"
                         >
                           <v-card>
+                            <v-toolbar
+                              density="compact"
+                            >
+                              <v-toolbar-title text="Error Loading Data"></v-toolbar-title>
+                              <v-spacer></v-spacer>
+                              <v-btn
+                                icon="mdi-close"
+                                @click="sampleErrorID = null"
+                              >
+                              </v-btn>
+                            </v-toolbar>
                             <v-card-text>
                               There was an error loading data for this selection. Either there is no data for the
                               region/time range/molecule combination that you selected, or there was an error loading
                               data from the server. You can delete this selection and try making a new one.
                             </v-card-text>
-                            <v-row>
-                              <v-spacer></v-spacer>
-                              <v-btn @click="sampleErrorID = null">Close</v-btn>
-                            </v-row>
                           </v-card>
                         </v-dialog>
                       </template>
@@ -1894,9 +1904,6 @@ async function fetchDataForSelection(sel: UserSelectionType) {
     sampleErrors.value[sel.id] = error instanceof Error ? error.message : String(error);
     loadingSamples.value = "error";
   }
-
-  // sampleErrors.value[sel.id] = "Failed!";
-  // loadingSamples.value = "error";
 
   sel.loading = false;
 
@@ -3684,8 +3691,9 @@ canvas.maplibregl-canvas {
   background-color: whitesmoke;
 }
 
-.selection-item {
-  height: fit-content;
+.dataset-loading {
+  display: flex;
+  flex-direction: row;
 }
 
 .dataset-loading-failed {

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -812,7 +812,7 @@
                     <v-list-item
                       v-bind="props"
                       class="selection-item"
-                      :style="{ 'background-color': `rgb(from ${sel.region.color} r g b / 0.35)` }"
+                      :style="{ 'background-color': sel.region.color }"
                       :ripple="touchscreen"
                       @click="() => {
                         if (touchscreen) {

--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -61,7 +61,7 @@
               indeterminate
             ></v-progress-linear>
           </template>
-          Get Data
+          Access Data
         </v-btn>
         <v-btn
           color="secondary"

--- a/src/components/SelectionComposer.vue
+++ b/src/components/SelectionComposer.vue
@@ -82,12 +82,10 @@ import { v4 } from "uuid";
 
 import type { MappingBackends, RectangleSelection, TimeRange, UserSelection } from "../types";
 import type { MillisecondRange } from "../types/datetime";
-import type { TempoDataService } from "../esri/services/TempoDataService";
-import { type MoleculeType, ESRI_URLS, MOLECULE_OPTIONS } from "../esri/utils";
+import { type MoleculeType, MOLECULE_OPTIONS } from "../esri/utils";
 import { atleast1d } from "../utils/atleast1d";
 import { formatTimeRange } from "../utils/timeRange";
 
-let selectionCount = 0; // for naming selections
 const selectedTimeRange = ref<TimeRange | null>(null);
 
 interface SelectionComposerProps {
@@ -95,7 +93,6 @@ interface SelectionComposerProps {
   timeRanges: TimeRange[];
   regions: RectangleSelectionType[];
   disabled?: { region?: boolean; timeRange?: boolean; molecule?: boolean };
-  tempoDataService: TempoDataService;
 }
 
 const props = defineProps<SelectionComposerProps>();
@@ -105,7 +102,6 @@ const emit = defineEmits<{
 }>();
 
 const loading = ref(false);
-const error = ref<string | null>(null);
 
 type RectangleSelectionType = RectangleSelection<typeof props.backend>;
 
@@ -147,8 +143,6 @@ async function composeSelection(): Promise<UserSelection | null> {
     return null;
   }
   
-  selectionCount += 1;
-  
   const timeRanges = atleast1d(draft.timeRange);
   // Add to available list if new custom
   const timeRange: TimeRange = { id: v4(), name: 'Selection Range', description: formatTimeRange(timeRanges), range: timeRanges.length === 1 ? timeRanges[0] : timeRanges };
@@ -157,31 +151,11 @@ async function composeSelection(): Promise<UserSelection | null> {
     region: draft.region, // as { id: string; name: string; rectangle: RectangleSelectionInfo; color: string; layer?: unknown },
     timeRange,
     molecule: draft.molecule as MoleculeType,
-    name: `Selection ${selectionCount}`
   };
-  await fetchDataForSelection(sel);
-  if (error.value === null) {
-    emit("create", sel);
-  }
+  emit("create", sel);
   return sel;
 }
 
-async function fetchDataForSelection(sel: UserSelection) {
-  const timeRanges = atleast1d(sel.timeRange.range);
-  
-  try {
-    props.tempoDataService.setBaseUrl(ESRI_URLS[sel.molecule].url);
-    error.value = null;
-    loading.value = true;
-    const data = await props.tempoDataService.fetchTimeseriesData(sel.region.geometryInfo, timeRanges);
-    sel.samples = data.values;
-    sel.errors = data.errors;
-    console.log(`Fetched data for ${timeRanges.length} time range(s)`);
-  } catch (err) {
-    error.value = "error";
-  }
-  loading.value = false;
-}
 
 function reset() {
   draftUserSelection.value = { region: null, timeRange: null, molecule: null };

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,7 +167,6 @@ export interface UserSelection {
   region: any;
   timeRange: TimeRange;
   molecule: string;
-  name: string; // not user editable
   samples?: Record<number, AggValue>;
   errors?: Record<number, DataPointError>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,7 @@ export interface TimeRange {
 
 export interface UserSelection {
   id: string;
+  loading?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   region: any;
   timeRange: TimeRange;

--- a/src/utils/timeRange.ts
+++ b/src/utils/timeRange.ts
@@ -24,7 +24,7 @@ export function formatTimeRange(ranges: MillisecondRange | MillisecondRange[]): 
 
 export function getTimeRangeDisplay(sel: UserSelection): string {
   if (!sel.timeRange || !sel.timeRange.range) {
-    return `No time range set for selection ${sel.name}`;
+    return `No time range set for selection ${sel.id}`;
   }
   return formatTimeRange(sel.timeRange.range);
 }


### PR DESCRIPTION
This PR partially addresses #39 - in particular, the "Datasets" section. The changes here are meant to address the items in that section.

The only additional concern is how to handle data loading failures now that the "Access Data" button doesn't block dataset creation until it's successful. Per a team discussion, the approach that this takes is to move the loading bar into the dataset row. If the loading fails, the loading bar then shows this. Clicking the help icon that pops up in this case gives an error message dialog. I suspect that the actual error message won't be helpful to a user, so this just gives a generic error message for now.