### PR TITLE
Use region name for timeseries graph traces

### DIFF
--- a/src/components/TimeseriesGraph.vue
+++ b/src/components/TimeseriesGraph.vue
@@ -85,7 +85,7 @@ function renderPlot() {
       mode: "lines+markers",
       legendgroup: legendGroup,
       showlegend: true,
-      name: data.name,
+      name: data.region.name,
       marker: { color: regionColor },
     });
 
@@ -120,7 +120,7 @@ function renderPlot() {
         line: { width: 0 },
         showlegend: false,
         legendgroup: legendGroup,
-        name: data.name,
+        name: data.region.name,
         marker: { color: regionColor },
         visible: props.showErrors,
       });
@@ -134,7 +134,7 @@ function renderPlot() {
         fill: "tonexty",
         showlegend: false,
         legendgroup: legendGroup,
-        name: data.name,
+        name: data.region.name,
         marker: { color: regionColor },
         visible: props.showErrors,
       });


### PR DESCRIPTION
We had been using the selection names as the trace names in the timeseries graph, but selections no longer have a name (which is why we were back to getting "trace 0"-style names). This PR updates the timeseries traces to use the names of the relevant regions instead.