### PR TITLE
Data creation UI, part 2

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -759,243 +759,247 @@
                     </v-list>
                   </template>
                 </v-expansion-panel>
-              </v-expansion-panels>
-            </div>
-
-            <div id="selections">
-              <v-btn
-                size="small"
-                :active="createSelectionActive"
-                @click="createSelectionActive = !createSelectionActive"
-                class="mt-3 ml-3"
-              >
-                <template #prepend>
-                  <v-icon v-if="!createSelectionActive" icon="mdi-plus"></v-icon>
-                </template>
-                {{ createSelectionActive ? "Cancel" : "New Dataset" }}
-              </v-btn>
-              <selection-composer
-                v-show="createSelectionActive"
-                :backend="BACKEND"
-                :time-ranges="availableTimeRanges"
-                :regions="availableRegions"
-                :disabled="{ region: rectangleSelectionActive, point: pointSelectionActive, timeRange: createTimeRangeActive }"
-                @create="handleSelectionCreated"
-                :tempo-data-service="tempoDataService"
-              >
-              </selection-composer>
-              <div id="sample-info" v-if="selections.length>0" style="margin-top: 1em;" class="pl-3">
-
-                <h3>My Datasets</h3>
-                <v-list>
-                  <v-hover
-                    v-slot="{ isHovering, props }"
-                    v-for="sel in selections"
-                    :key="sel.id"
+                <v-expansion-panel
+                  title="Datasets"
+                  class="mt-3"
+                >
+                <template #text>
+                  <v-btn
+                    size="small"
+                    :active="createSelectionActive"
+                    @click="createSelectionActive = !createSelectionActive"
+                    class="mt-3 ml-3"
                   >
-                    <v-list-item
-                      v-bind="props"
-                      :ref="(el) => datasetRowRefs[sel.id] = el"
-                      class="selection-item"
-                      :style="{ 'background-color': sel.region.color }"
-                      :ripple="touchscreen"
-                      @click="() => {
-                        if (touchscreen) {
-                          openSelection = (openSelection == sel.id) ? null : sel.id;
-                        }
-                      }"
-                      lines="two"
-                    >
-                      <template #default>
-                        <div>
-                          <v-chip size="small">{{ sel.region.name }}</v-chip>
-                          <v-chip size="small">{{ moleculeName(sel.molecule) }}</v-chip>
-                          <v-chip v-if="sel.timeRange" size="small" class="text-caption">
-                            {{ sel.timeRange.description }}
-                          </v-chip>
-                        </div>
-                        <div
-                          v-if="sel.loading || !sel.samples"
-                          class="dataset-loading"
-                        >
-                          <v-progress-linear
-                            :class="['dataset-loading-progress', !(sel.loading && sel.samples) ? 'dataset-loading-failed' : '']"
-                            :active="sel.loading || !sel.samples"
-                            :color="sel.loading ? 'primary' : 'red'"
-                            :indeterminate="sel.loading"
-                            :value="!sel.loading ? 100 : 0"
-                            :striped="!sel.loading"
-                            bottom
-                            rounded
-                            height="20"
-                          >
-                            <template #default>
-                              <span class="text-subtitle-2">
-                                {{ sel.loading ? 'Data Loading' : (!sel.samples ? 'Error Loading Data' : '') }}
-                              </span>
-                            </template>
-                          </v-progress-linear>
-                          <div v-if="!(sel.loading || sel.samples)">
-                            <v-tooltip
-                              text="Failure info"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-help-circle"
-                                  variant="plain"
-                                  @click="() => sampleErrorID = sel.id"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                            <v-tooltip
-                              text="Remove selection"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-trash-can"
-                                  variant="plain"
-                                  @click="() => deleteSelection(sel)"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                          </div>
-                        </div>
+                    <template #prepend>
+                      <v-icon v-if="!createSelectionActive" icon="mdi-plus"></v-icon>
+                    </template>
+                    {{ createSelectionActive ? "Cancel" : "New Dataset" }}
+                  </v-btn>
+                  <selection-composer
+                    v-show="createSelectionActive"
+                    :backend="BACKEND"
+                    :time-ranges="availableTimeRanges"
+                    :regions="availableRegions"
+                    :disabled="{ region: rectangleSelectionActive, point: pointSelectionActive, timeRange: createTimeRangeActive }"
+                    @create="handleSelectionCreated"
+                    :tempo-data-service="tempoDataService"
+                  >
+                  </selection-composer>
+                  <div id="sample-info" v-if="selections.length>0" style="margin-top: 1em;" class="pl-3">
 
-                        <v-expand-transition>
-                          <div
-                            class="selection-icons"
-                            v-show="sel.samples && (touchscreen ? openSelection == sel.id : isHovering)"
-                          >
-                            <v-tooltip
-                              text="Change Selection Name"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-pencil"
-                                  @click="() => editSelectionName(sel)"
-                                  variant="plain"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                            <v-tooltip
-                              text="Get Center Point Sample"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  :loading="loadingPointSample === sel.id"
-                                  icon="mdi-image-filter-center-focus"
-                                  variant="plain"
-                                  @click="() => fetchCenterPointDataForSelection(sel)"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip> 
-                            <v-tooltip
-                              text="Show table"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-table"
-                                  :disabled="!sel.samples"
-                                  variant="plain"
-                                  @click="() => tableSelection = sel"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                            <v-tooltip
-                              text="Show graph"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-chart-line"
-                                  :disabled="!sel.samples"
-                                  variant="plain"
-                                  @click="() => openGraphs[sel.id] = true"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                            <v-tooltip
-                              text="Remove selection"
-                              location="top"
-                            >
-                              <template #activator="{ props }">
-                                <v-btn
-                                  v-bind="props"
-                                  size="x-small"
-                                  icon="mdi-trash-can"
-                                  variant="plain"
-                                  @click="() => deleteSelection(sel)"
-                                ></v-btn>
-                              </template>
-                            </v-tooltip>
-                          </div>
-                        </v-expand-transition>
-                        <cds-dialog
-                          :title="graphTitle(sel)"
-                          v-model="openGraphs[sel.id]"
-                          title-color="#F44336"
-                          draggable
-                          persistent
-                          :scrim="false"
-                          :modal="false"
+                    <h3>My Datasets</h3>
+                    <v-list>
+                      <v-hover
+                        v-slot="{ isHovering, props }"
+                        v-for="sel in selections"
+                        :key="sel.id"
+                      >
+                        <v-list-item
+                          v-bind="props"
+                          :ref="(el) => datasetRowRefs[sel.id] = el"
+                          class="selection-item"
+                          :style="{ 'background-color': sel.region.color }"
+                          :ripple="touchscreen"
+                          @click="() => {
+                            if (touchscreen) {
+                              openSelection = (openSelection == sel.id) ? null : sel.id;
+                            }
+                          }"
+                          lines="two"
                         >
-                          <v-checkbox
-                            v-model="showErrorBands"
-                            label="Show Errors"
-                            density="compact"
-                            hide-details
-                          >
-                          </v-checkbox>
-                          <timeseries-graph
-                            :data="sel ? [sel] : []"
-                            :show-errors="showErrorBands"
-                          />
-                        </cds-dialog>
-                        <v-dialog
-                          :model-value="sampleErrorID !== null"
-                          max-width="50%"
-                        >
-                          <v-card>
-                            <v-toolbar
-                              density="compact"
+                          <template #default>
+                            <div>
+                              <v-chip size="small">{{ sel.region.name }}</v-chip>
+                              <v-chip size="small">{{ moleculeName(sel.molecule) }}</v-chip>
+                              <v-chip v-if="sel.timeRange" size="small" class="text-caption">
+                                {{ sel.timeRange.description }}
+                              </v-chip>
+                            </div>
+                            <div
+                              v-if="sel.loading || !sel.samples"
+                              class="dataset-loading"
                             >
-                              <v-toolbar-title text="Error Loading Data"></v-toolbar-title>
-                              <v-spacer></v-spacer>
-                              <v-btn
-                                icon="mdi-close"
-                                @click="sampleErrorID = null"
+                              <v-progress-linear
+                                :class="['dataset-loading-progress', !(sel.loading && sel.samples) ? 'dataset-loading-failed' : '']"
+                                :active="sel.loading || !sel.samples"
+                                :color="sel.loading ? 'primary' : 'red'"
+                                :indeterminate="sel.loading"
+                                :value="!sel.loading ? 100 : 0"
+                                :striped="!sel.loading"
+                                bottom
+                                rounded
+                                height="20"
                               >
-                              </v-btn>
-                            </v-toolbar>
-                            <v-card-text>
-                              There was an error loading data for this selection. Either there is no data for the
-                              region/time range/molecule combination that you selected, or there was an error loading
-                              data from the server. You can delete this selection and try making a new one.
-                            </v-card-text>
-                          </v-card>
-                        </v-dialog>
-                      </template>
-                    </v-list-item>
-                  </v-hover>
-                </v-list>
-              </div>
+                                <template #default>
+                                  <span class="text-subtitle-2">
+                                    {{ sel.loading ? 'Data Loading' : (!sel.samples ? 'Error Loading Data' : '') }}
+                                  </span>
+                                </template>
+                              </v-progress-linear>
+                              <div v-if="!(sel.loading || sel.samples)">
+                                <v-tooltip
+                                  text="Failure info"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-help-circle"
+                                      variant="plain"
+                                      @click="() => sampleErrorID = sel.id"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                                <v-tooltip
+                                  text="Remove selection"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-trash-can"
+                                      variant="plain"
+                                      @click="() => deleteSelection(sel)"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                              </div>
+                            </div>
+
+                            <v-expand-transition>
+                              <div
+                                class="selection-icons"
+                                v-show="sel.samples && (touchscreen ? openSelection == sel.id : isHovering)"
+                              >
+                                <v-tooltip
+                                  text="Change Selection Name"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-pencil"
+                                      @click="() => editSelectionName(sel)"
+                                      variant="plain"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                                <v-tooltip
+                                  text="Get Center Point Sample"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      :loading="loadingPointSample === sel.id"
+                                      icon="mdi-image-filter-center-focus"
+                                      variant="plain"
+                                      @click="() => fetchCenterPointDataForSelection(sel)"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip> 
+                                <v-tooltip
+                                  text="Show table"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-table"
+                                      :disabled="!sel.samples"
+                                      variant="plain"
+                                      @click="() => tableSelection = sel"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                                <v-tooltip
+                                  text="Show graph"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-chart-line"
+                                      :disabled="!sel.samples"
+                                      variant="plain"
+                                      @click="() => openGraphs[sel.id] = true"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                                <v-tooltip
+                                  text="Remove selection"
+                                  location="top"
+                                >
+                                  <template #activator="{ props }">
+                                    <v-btn
+                                      v-bind="props"
+                                      size="x-small"
+                                      icon="mdi-trash-can"
+                                      variant="plain"
+                                      @click="() => deleteSelection(sel)"
+                                    ></v-btn>
+                                  </template>
+                                </v-tooltip>
+                              </div>
+                            </v-expand-transition>
+                            <cds-dialog
+                              :title="graphTitle(sel)"
+                              v-model="openGraphs[sel.id]"
+                              title-color="#F44336"
+                              draggable
+                              persistent
+                              :scrim="false"
+                              :modal="false"
+                            >
+                              <v-checkbox
+                                v-model="showErrorBands"
+                                label="Show Errors"
+                                density="compact"
+                                hide-details
+                              >
+                              </v-checkbox>
+                              <timeseries-graph
+                                :data="sel ? [sel] : []"
+                                :show-errors="showErrorBands"
+                              />
+                            </cds-dialog>
+                            <v-dialog
+                              :model-value="sampleErrorID !== null"
+                              max-width="50%"
+                            >
+                              <v-card>
+                                <v-toolbar
+                                  density="compact"
+                                >
+                                  <v-toolbar-title text="Error Loading Data"></v-toolbar-title>
+                                  <v-spacer></v-spacer>
+                                  <v-btn
+                                    icon="mdi-close"
+                                    @click="sampleErrorID = null"
+                                  >
+                                  </v-btn>
+                                </v-toolbar>
+                                <v-card-text>
+                                  There was an error loading data for this selection. Either there is no data for the
+                                  region/time range/molecule combination that you selected, or there was an error loading
+                                  data from the server. You can delete this selection and try making a new one.
+                                </v-card-text>
+                              </v-card>
+                            </v-dialog>
+                          </template>
+                        </v-list-item>
+                      </v-hover>
+                    </v-list>
+                  </div>
+                </template>
+              </v-expansion-panel>
+            </v-expansion-panels>
             </div>
           </div>
           

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -2145,7 +2145,8 @@ function deleteSelection(sel: UserSelectionType) {
     }
   }
 
-  datasetRowRefs.value[sel.id] = null;
+  delete datasetRowRefs.value[sel.id];
+  delete openGraphs.value[sel.id];
 }
 
 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1986,9 +1986,7 @@ async function fetchDataForSelection(sel: UserSelectionType) {
 
   sel.loading = false;
 
-  nextTick(() => {
-    markSelectionUpdated(sel);
-  });
+  markSelectionUpdated(sel);
 
 }
 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -979,6 +979,10 @@
                   :title="graphSelectionTitle"
                   v-model="showGraph"
                   title-color="#F44336"
+                  draggable
+                  persistent
+                  :scrim="false"
+                  :modal="false"
                 >
                   <v-checkbox
                     v-model="showErrorBands"
@@ -1002,6 +1006,10 @@
         <cds-dialog
           title="Nitrogen Dioxide Data"
           v-model="showNO2Graph"
+          draggable
+          persistent
+          :modal="false"
+          :scrim="false"
         >
           <v-checkbox
             v-model="showErrorBands"
@@ -1022,6 +1030,10 @@
         <cds-dialog
           title="Ozone Data"
           v-model="showO3Graph"
+          draggable
+          persistent
+          :modal="false"
+          :scrim="false"
         >
           <v-checkbox
             v-model="showErrorBands"
@@ -1042,6 +1054,10 @@
         <cds-dialog
           title="Formaldehyde Data"
           v-model="showHCHOGraph"
+          draggable
+          persistent
+          :modal="false"
+          :scrim="false"
         >
           <v-checkbox
             v-model="showErrorBands"
@@ -1102,6 +1118,10 @@
         <cds-dialog 
           title="NO₂ Samples" 
           v-model="showTable"
+          draggable
+          persistent
+          :modal="false"
+          :scrim="false"
           >
           <div 
             v-if="loadingSamples === 'loading'" 

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -666,6 +666,38 @@
                 class="pl-3"
               >
                 <v-expansion-panel
+                  title="Time Ranges"
+                  class="mt-3"
+                >
+                  <template #text>
+                    <v-btn
+                      size="small"
+                      :active="createTimeRangeActive"
+                      @click="createTimeRangeActive = !createTimeRangeActive"
+                    >
+                      <template #prepend>
+                        <v-icon v-if="!createTimeRangeActive" icon="mdi-plus"></v-icon>
+                      </template>
+                      {{ createTimeRangeActive ? "Cancel" : "New Time Range" }}
+                    </v-btn>
+                    <date-time-range-selection
+                      v-if="createTimeRangeActive"
+                      :current-date="singleDateSelected"
+                      :selected-timezone="selectedTimezone"
+                      :allowed-dates="uniqueDays"
+                      @ranges-change="handleDateTimeRangeSelectionChange"
+                    />
+                    <v-list>
+                      <v-list-item
+                        v-for="(timeRange, index) in availableTimeRanges"
+                        :key="index"
+                        :title="timeRange.name"
+                        :subtitle="timeRange.description"
+                      ></v-list-item>
+                    </v-list>
+                  </template>
+                </v-expansion-panel>
+                <v-expansion-panel
                   title="Regions"
                   class="mt-3"
                 >
@@ -727,38 +759,7 @@
                     </v-list>
                   </template>
                 </v-expansion-panel>
-                <v-expansion-panel
-                  title="Date/Time Range"
-                  class="mt-3"
-                >
-                  <template #text>
-                    <v-btn
-                      size="small"
-                      :active="createTimeRangeActive"
-                      @click="createTimeRangeActive = !createTimeRangeActive"
-                    >
-                      <template #prepend>
-                        <v-icon v-if="!createTimeRangeActive" icon="mdi-plus"></v-icon>
-                      </template>
-                      {{ createTimeRangeActive ? "Cancel" : "New Time Range" }}
-                    </v-btn>
-                    <date-time-range-selection
-                      v-if="createTimeRangeActive"
-                      :current-date="singleDateSelected"
-                      :selected-timezone="selectedTimezone"
-                      :allowed-dates="uniqueDays"
-                      @ranges-change="handleDateTimeRangeSelectionChange"
-                    />
-                    <v-list>
-                      <v-list-item
-                        v-for="(timeRange, index) in availableTimeRanges"
-                        :key="index"
-                        :title="timeRange.name"
-                        :subtitle="timeRange.description"
-                      ></v-list-item>
-                    </v-list>
-                  </template>
-                </v-expansion-panel>
+
                 <v-expansion-panel
                   title="Datasets"
                   class="mt-3"

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -927,7 +927,7 @@
                                   icon="mdi-chart-line"
                                   :disabled="!sel.samples"
                                   variant="plain"
-                                  @click="() => graphSelection = sel"
+                                  @click="() => openGraphs[sel.id] = true"
                                 ></v-btn>
                               </template>
                             </v-tooltip>
@@ -947,6 +947,27 @@
                             </v-tooltip>
                           </div>
                         </v-expand-transition>
+                        <cds-dialog
+                          :title="graphTitle(sel)"
+                          v-model="openGraphs[sel.id]"
+                          title-color="#F44336"
+                          draggable
+                          persistent
+                          :scrim="false"
+                          :modal="false"
+                        >
+                          <v-checkbox
+                            v-model="showErrorBands"
+                            label="Show Errors"
+                            density="compact"
+                            hide-details
+                          >
+                          </v-checkbox>
+                          <timeseries-graph
+                            :data="sel ? [sel] : []"
+                            :show-errors="showErrorBands"
+                          />
+                        </cds-dialog>
                         <v-dialog
                           :model-value="sampleErrorID !== null"
                           max-width="50%"
@@ -974,28 +995,6 @@
                     </v-list-item>
                   </v-hover>
                 </v-list>
-
-                <cds-dialog
-                  :title="graphSelectionTitle"
-                  v-model="showGraph"
-                  title-color="#F44336"
-                  draggable
-                  persistent
-                  :scrim="false"
-                  :modal="false"
-                >
-                  <v-checkbox
-                    v-model="showErrorBands"
-                    label="Show Errors"
-                    density="compact"
-                    hide-details
-                  >
-                  </v-checkbox>
-                  <timeseries-graph
-                    :data="graphSelection ? [graphSelection] : []"
-                    :show-errors="showErrorBands"
-                  />
-                </cds-dialog>
               </div>
             </div>
           </div>
@@ -1641,38 +1640,14 @@ type UserSelectionType = UserSelection;
 const selections = ref<UserSelectionType[]>([]);
 const selection = ref<UserSelectionType | null>(null);
 const tableSelection = ref<UserSelectionType | null>(null);
-const graphSelection = ref<UserSelectionType | null>(null);
+const openGraphs = ref<Record<string,boolean>>({});
 
-const showTable = computed({
-  get() {
-    return tableSelection.value != null;
-  },
-  set(value: boolean) {
-    if (!value) {
-      tableSelection.value = null;
-    }
-  }
-});
 
-const showGraph = computed({
-  get() {
-    return graphSelection.value != null;
-  },
-  set(value: boolean) {
-    if (!value) {
-      graphSelection.value = null;
-    }
-  }
-});
-
-const graphSelectionTitle = computed(() => {
-  if (!graphSelection.value) {
-    return '';
-  }
-  const molecule = graphSelection.value.molecule;
+function graphTitle(selection: UserSelection): string {
+  const molecule = selection.molecule;
   const molTitle = MOLECULE_OPTIONS.find(m => m.value === molecule)?.title || '';
-  return `${molTitle} Time Series for ${graphSelection.value.region.name}`;
-});
+  return `${molTitle} Time Series for ${selection.region.name}`;
+}
 
 const showNO2Graph = ref(false);
 const no2GraphData = computed(() =>{

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -760,6 +760,12 @@
                   </template>
                 </v-expansion-panel>
 
+                <v-divider
+                  class="mt-3"
+                  opacity="1"
+                >
+                </v-divider>
+
                 <v-expansion-panel
                   title="Datasets"
                   class="mt-3"

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -1008,79 +1008,79 @@
               </v-expansion-panel>
             </v-expansion-panels>
             </div>
-          </div>
           
-          <v-btn v-if="no2GraphData.length > 0" @click="showNO2Graph = true">
-          Show NO₂ Graph
-        </v-btn>
-        <cds-dialog
-          title="Nitrogen Dioxide Data"
-          v-model="showNO2Graph"
-          draggable
-          persistent
-          :modal="false"
-          :scrim="false"
-        >
-          <v-checkbox
-            v-model="showErrorBands"
-            label="Show Errors"
-            density="compact"
-            hide-details
-          >
-          </v-checkbox>
-          <timeseries-graph
-            :data="no2GraphData.length > 0 ? no2GraphData : []"
-            :show-errors="showErrorBands"
-          />
-        </cds-dialog>
+            <v-btn v-if="no2GraphData.length > 0" @click="showNO2Graph = true">
+              Show NO₂ Graph
+            </v-btn>
+            <cds-dialog
+              title="Nitrogen Dioxide Data"
+              v-model="showNO2Graph"
+              draggable
+              persistent
+              :modal="false"
+              :scrim="false"
+            >
+              <v-checkbox
+                v-model="showErrorBands"
+                label="Show Errors"
+                density="compact"
+                hide-details
+              >
+              </v-checkbox>
+              <timeseries-graph
+                :data="no2GraphData.length > 0 ? no2GraphData : []"
+                :show-errors="showErrorBands"
+              />
+            </cds-dialog>
 
-        <v-btn v-if="o3GraphData.length > 0" @click="showO3Graph = true">
-          Show Ozone Graph
-        </v-btn>
-        <cds-dialog
-          title="Ozone Data"
-          v-model="showO3Graph"
-          draggable
-          persistent
-          :modal="false"
-          :scrim="false"
-        >
-          <v-checkbox
-            v-model="showErrorBands"
-            label="Show Errors"
-            density="compact"
-            hide-details
-          >
-          </v-checkbox>
-          <timeseries-graph
-            :data="o3GraphData.length > 0 ? o3GraphData : []"
-            :show-errors="showErrorBands"
-          />
-        </cds-dialog>
-        
-        <v-btn v-if="hchoGraphData.length > 0" @click="showHCHOGraph = true">
-          Show Formaldehyde Graph
-        </v-btn>
-        <cds-dialog
-          title="Formaldehyde Data"
-          v-model="showHCHOGraph"
-          draggable
-          persistent
-          :modal="false"
-          :scrim="false"
-        >
-          <v-checkbox
-            v-model="showErrorBands"
-            label="Show Errors"
-            density="compact"
-            hide-details
-          >
-          </v-checkbox>
-          <timeseries-graph
-            :data="hchoGraphData.length > 0 ? hchoGraphData : []"
-            :show-errors="showErrorBands"
-          />
-        </cds-dialog>
+            <v-btn v-if="o3GraphData.length > 0" @click="showO3Graph = true">
+              Show Ozone Graph
+            </v-btn>
+            <cds-dialog
+              title="Ozone Data"
+              v-model="showO3Graph"
+              draggable
+              persistent
+              :modal="false"
+              :scrim="false"
+            >
+              <v-checkbox
+                v-model="showErrorBands"
+                label="Show Errors"
+                density="compact"
+                hide-details
+              >
+              </v-checkbox>
+              <timeseries-graph
+                :data="o3GraphData.length > 0 ? o3GraphData : []"
+                :show-errors="showErrorBands"
+              />
+            </cds-dialog>
+            
+            <v-btn v-if="hchoGraphData.length > 0" @click="showHCHOGraph = true">
+              Show Formaldehyde Graph
+            </v-btn>
+            <cds-dialog
+              title="Formaldehyde Data"
+              v-model="showHCHOGraph"
+              draggable
+              persistent
+              :modal="false"
+              :scrim="false"
+            >
+              <v-checkbox
+                v-model="showErrorBands"
+                label="Show Errors"
+                density="compact"
+                hide-details
+              >
+              </v-checkbox>
+              <timeseries-graph
+                :data="hchoGraphData.length > 0 ? hchoGraphData : []"
+                :show-errors="showErrorBands"
+              />
+            </cds-dialog>
+        </div>
         
         <v-dialog
           v-model="showEditRegionNameDialog"
@@ -1653,6 +1653,17 @@ const selection = ref<UserSelectionType | null>(null);
 const tableSelection = ref<UserSelectionType | null>(null);
 const openGraphs = ref<Record<string,boolean>>({});
 
+const showTable = computed({
+  get() {
+    return tableSelection.value != null;
+  },
+  set(value: boolean) {
+    if (!value) {
+      tableSelection.value = null;
+    }
+  }
+});
+
 
 function graphTitle(selection: UserSelection): string {
   const molecule = selection.molecule;
@@ -1976,9 +1987,16 @@ async function fetchDataForSelection(sel: UserSelectionType) {
   sel.loading = false;
 
   nextTick(() => {
-    datasetRowRefs.value[sel.id]?.$forceUpdate();
+    markSelectionUpdated(sel);
   });
 
+}
+
+function markSelectionUpdated(selection: UserSelectionType) {
+  const index = selections.value.findIndex(sel => sel.id === selection.id);
+  if (index >= 0) {
+    selections.value[index] = { ...selection };
+  }
 }
 
 // 30 is the value we have been using

--- a/src/components/CDSDialog.vue
+++ b/src/components/CDSDialog.vue
@@ -1,7 +1,10 @@
 <template>
   <v-dialog 
-    :class="`cds-dialog ${displayedShortTitle.toLowerCase().replace(/ /g, '-')}-cds-dialog`" 
+    :class="['cds-dialog', `${displayedShortTitle.toLowerCase().replace(/ /g, '-')}-cds-dialog`, !modal ? 'nonmodal' : '']" 
     v-model="showDialog" 
+    :scrim="scrim"
+    :persistent="persistent"
+    :no-click-animation="!modal"
     >
     <!-- add the activator slot, but only use it if the appropriate value is given for activator -->
      <template v-slot:activator="$attrs">
@@ -64,6 +67,9 @@ interface CDSDialogProps {
   shortTitle?: string;
   draggable?: boolean;
   button?: boolean;
+  scrim?: boolean;
+  persistent?: boolean;
+  modal?: boolean;
 }
 
 const props = withDefaults(defineProps<CDSDialogProps>(), {
@@ -73,6 +79,9 @@ const props = withDefaults(defineProps<CDSDialogProps>(), {
   draggable: false,
   button: false,
   titleColor: "primary",
+  scrim: true,
+  persistent: false,
+  modal: true,
 });
 
 const emit = defineEmits<{
@@ -147,5 +156,17 @@ watch(() => props.modelValue, value => {
 .cds-dialog .v-card-text {
   height: fit-content;
   max-height: 60vh;
+}
+
+.cds-dialog.nonmodal {
+
+  .v-overlay__content {
+    visibility: hidden;
+
+    .v-card {
+      visibility: visible;
+    }
+  }
+
 }
 </style>


### PR DESCRIPTION
This PR addresses the last item in the "Datasets" section of #39:
* Moves the datasets controls inside the accordion
* Adds a divider between the first two accordion panels and the "Datasets" one
* Moves the time ranges panel to be first (before regions)
* Moves the graph buttons inside the red outlined box

I built this on top of #58 in order to prevent conflicts in the template.