### PR TITLE
limit year range to allowed dates

### DIFF
--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -546,7 +546,7 @@
                     :preview-format="(date: Date | null) => date?.toDateString()"
                     no-today
                     dark
-                    :year-range="[uniqueDays[0].getFullYear(), uniqueDays[uniqueDays.length - 1].getFullYear()]"
+                    :year-range="[uniqueDays[0]?.getFullYear(), uniqueDays[uniqueDays.length - 1]?.getFullYear()]"
                   >
                     <template #action-buttons>
                       <button

--- a/src/TempoLite.vue
+++ b/src/TempoLite.vue
@@ -546,6 +546,7 @@
                     :preview-format="(date: Date | null) => date?.toDateString()"
                     no-today
                     dark
+                    :year-range="[uniqueDays[0].getFullYear(), uniqueDays[uniqueDays.length - 1].getFullYear()]"
                   >
                     <template #action-buttons>
                       <button

--- a/src/date_time_range_selection/DateTimeRangeSelection.vue
+++ b/src/date_time_range_selection/DateTimeRangeSelection.vue
@@ -58,6 +58,7 @@
               text-input
               :teleport="true"
               dark
+              :year-range="[allowedDates ? allowedDates[0].getFullYear() : 2023, allowedDates ? allowedDates[allowedDates.length - 1].getFullYear() : new Date().getFullYear()]"
             />
           </div>
 
@@ -134,6 +135,7 @@
               text-input
               :teleport="true"
               dark
+              :year-range="[allowedDates ? allowedDates[0].getFullYear() : 2023, allowedDates ? allowedDates[allowedDates.length - 1].getFullYear() : new Date().getFullYear()]"
             />
           </div>
 
@@ -151,6 +153,7 @@
               text-input
               :teleport="true"
               dark
+              :year-range="[allowedDates ? allowedDates[0].getFullYear() : 2023, allowedDates ? allowedDates[allowedDates.length - 1].getFullYear() : new Date().getFullYear()]"
             />
           </div>
         </div>
@@ -172,6 +175,7 @@
               text-input
               :teleport="true"
               dark
+              :year-range="[allowedDates ? allowedDates[0].getFullYear() : 2023, allowedDates ? allowedDates[allowedDates.length - 1].getFullYear() : new Date().getFullYear()]"
             />
           </div>
         </div>


### PR DESCRIPTION
Simple update to limite the range of years to those spanned by the allowed dates of each `date-picker` component