### PR TITLE
Fix a few region issues

### DIFF
--- a/src/components/DatasetControls.vue
+++ b/src/components/DatasetControls.vue
@@ -87,7 +87,7 @@
                   :key="index"
                   :title="region.name"
                   :style="{ 'background-color': region.color }"
-                  @click="() => lastFocusedRegion = region"
+                  @click="() => focusRegion = region"
                 >
                   <template #append>
                     <!-- New: Edit Geometry button (disabled if any selection using region has samples) -->
@@ -104,7 +104,10 @@
                       v-tooltip="'Edit Name'"
                       icon="mdi-pencil"
                       color="white"
-                      @click="() => editRegionName(region as UnifiedRegionType)"
+                      @click="(event: MouseEvent | KeyboardEvent) => {
+                        editRegionName(region as UnifiedRegionType);
+                        event.stopPropagation();
+                      }"
                     ></v-btn>
                     <v-btn
                       v-if="!store.regionHasDatasets(region as UnifiedRegionType)"
@@ -112,7 +115,10 @@
                       v-tooltip="'Delete'"
                       icon="mdi-delete"
                       color="white"
-                      @click="() => store.deleteRegion(region as UnifiedRegionType)"
+                      @click="(event: MouseEvent | KeyboardEvent) => {
+                        store.deleteRegion(region as UnifiedRegionType);
+                        event.stopPropagation();
+                      }"
                     ></v-btn>
                   </template>
                 </v-list-item>
@@ -489,7 +495,7 @@ const {
   selectedTimezone,
   uniqueDays,
   selectionActive,
-  lastFocusedRegion,
+  focusRegion,
 } = storeToRefs(store);
 
 function plotlyDragPredicate(element: HTMLElement): boolean {

--- a/src/components/MapWithControls.vue
+++ b/src/components/MapWithControls.vue
@@ -261,7 +261,7 @@ const {
   currentTempoDataService,
   maxSampleCount,
   colorMap,
-  lastFocusedRegion,
+  focusRegion,
 } = storeToRefs(store);
 
 function createSelectionComputed(selection: SelectionType): WritableComputedRef<boolean> {
@@ -566,10 +566,13 @@ watch([showSamplingPreviewMarkers, regions, ()=> regions.value.length], (newVal)
   }
 });
 
-watch(lastFocusedRegion, region => {
+// TODO: This may need to be revisited when there are two maps
+watch(focusRegion, region => {
   if (region !== null) {
+    console.log(region);
     const bounds = regionBounds(region);
     fitBounds(map.value, bounds, true);
+    focusRegion.value = null;
   }
 });
 

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -249,6 +249,8 @@ const createTempoStore = <T extends MappingBackends>(backend: MappingBackends) =
     if (index < 0) {
       return;
     }
+    regions.value.splice(index, 1);
+
     // if (map.value && region.layer) {
     //   if (isRectangleSelection(region)) {
     //     removeRectangleLayer(map.value as Map, region.layer as unknown as StyleLayer);

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -36,7 +36,7 @@ const createTempoStore = <T extends MappingBackends>(backend: MappingBackends) =
   const opacitySliderUsedCount = ref(0);
 
   const selectionActive = ref<SelectionType>(null);
-  const lastFocusedRegion = ref<UnifiedRegionType | null>(null);
+  const focusRegion = ref<UnifiedRegionType | null>(null);
 
   const colorMap = computed(() => colorbarOptions[molecule.value].colormap.toLowerCase());
 
@@ -269,7 +269,7 @@ const createTempoStore = <T extends MappingBackends>(backend: MappingBackends) =
     timezoneOptions,
 
     selectionActive,
-    lastFocusedRegion,
+    focusRegion,
 
     regions,
     regionsCreatedCount,


### PR DESCRIPTION
This PR fixes a few issues relating to regions:
* Actually delete the region from the store in `deleteRegion`
* Prevent going to a region when renaming or deleting - this now only happens when clicking the rest of the row
* Fix an issue where selecting the same region multiple times doesn't work

One thing that this doesn't take care of is the fact that layers aren't removed when a region is deleted. I've been working on state serialization and the layer objects are an issue there as well, and I think both of those can be dealt with at once.