### PR TITLE
Don't serialize maps

### DIFF
--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -423,11 +423,12 @@ export function deserializeTempoStore(value: string): StateTree {
     }
     return parsed;
   } catch (error) {
+    console.error(error);
     return {};
   }
 }
 
-const OMIT = new Set(["selectionActive"]);
+const OMIT = new Set(["selectionActive", "maps"]);
 export function serializeTempoStore(store: ReturnType<typeof useTempoStore>): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const state: Record<string, any> = {};


### PR DESCRIPTION
The addition of the map list to the state in #94 inadvertently broke the state serialization due to the presence of the map objects. Thus this PR fixes the serialization by omitting the map list during serialization - they'll get re-added anyways when their components are mounted.