### PR TITLE
Fix reordering bug with power plants

### DIFF
--- a/src/components/LayerOrderControl.vue
+++ b/src/components/LayerOrderControl.vue
@@ -72,7 +72,7 @@ const displayOrder = computed({
     return currentOrder.value.slice().reverse();
   },
   set(value: string[]) {
-    controller?.setManagedOrder(value.slice().reverse());
+    controller?.setOrder(value.slice().reverse());
   }
 });
 
@@ -106,7 +106,7 @@ watch(powerPlantMode, (mode: number, oldMode: number) => {
     setLayerVisibility(mapRef.value, newLayerId, true);
   }
   currentOrder.value = order;
-  controller?.setManagedOrder(order);
+  controller?.setOrder(order);
 });
 </script>
 

--- a/src/composables/useMaplibreLayerOrderControl.ts
+++ b/src/composables/useMaplibreLayerOrderControl.ts
@@ -327,7 +327,19 @@ export class MaplibreLayerOrderControl extends PsuedoEvent {
       managedLayerMap.set(layer, index);
     });
     
-    this.desiredLayerOrder = newManagedOrder;
+    const newDesiredOrder: string[] = [];
+    let managedIndex = 0;
+    
+    for (const layer of this.desiredLayerOrder) {
+      if (managedLayerMap.has(layer)) {
+        newDesiredOrder.push(newManagedOrder[managedIndex]);
+        managedIndex++;
+      } else {
+        newDesiredOrder.push(layer);
+      }
+    }
+    
+    this.desiredLayerOrder = newDesiredOrder;
     this.maintainOrder();
     
   }


### PR DESCRIPTION
This PR fixes #116.

@johnarban does this make sense to you? In a case like this, where we're swapping out which layer (heatmap vs points) is displayed, it seemed simplest to me to just set the controller's order to be what we wanted.