### PR TITLE
Map view UI updates

### DIFF
--- a/src/components/MapControls.vue
+++ b/src/components/MapControls.vue
@@ -221,8 +221,7 @@ watch(molecule, (newMol: MoleculeType) => {
   flex-direction: row;
   flex-wrap: wrap;
   gap: 1rem;
-  flex: 1 1 210px; /* Grow, shrink, basis of 440px (2 x 220px dropdowns) */
-  // min-width: 220px; /* Minimum width - when smaller, children will wrap */
+  flex: 1 1 210px; 
 
   .map-dropdowns {
 


### PR DESCRIPTION
Per discussion with John and Jon, this re-arranges the map controls to save space. The 3 choices are in a row when possible, then the 2 dropdown menus will wrap under each other, then all 3 items will wrap into a column. (Thanks to copilot/Claude for help with the concept behind the div wrapping css, which I adjusted to make it actually do what we wanted).

I also updated the dropdown styling to look more unified with the calendar picker styling. I had some trouble with the "notch" for the label in the dropdown menu outline. You can see that the bottom of the outline right under the label notch has slightly different styling. I did the best I could to unify it based on how it was behaving, but if someone has time to take a look and properly fix it, that would be great, but probably not worth it unless it's a super easy fix that I missed.