### PR TITLE
Fix Broken Dev Deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -18,9 +18,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '18.17.1'
+          node-version: '20'
+      
+      - name: Use Yarn 4
+        run: |
+          corepack enable
+          yarn set version 4.5.3
 
       - name: Yarn install
         run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
     
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '18.17.1'
+          node-version: '20'
+      
+      - name: Use Yarn 4
+        run: |
+          corepack enable
+          yarn set version 4.5.3
+
 
       - name: Yarn install
         run: yarn install


### PR DESCRIPTION
The Github action was using `yarn 1.22.22` with `node 18.17.1`. For whatever reason the older version of yarn compiles and breaks something*. I am not sure what. I found using Yarn 1 with node 18, 20, 22 all resulted in broken apps when testing locally. 

So I have updated the node environment to use version 20 and set yarn to version 4.5.3 (the version I use) using [corepack](https://yarnpkg.com/corepack). 

To test this you need to have `nvm` (node version manager). You can switch between yarn version if you have corepack (`corepack enable`) with `yarn set version <versionNumber>`, make sure to delete `node_modules`, `.yarn` (if present). 


The two live version are

Broke: https://johnarban.github.io/tempods-js/testing/
Fixed: https://johnarban.github.io/tempods-js/testingfixed


*I am pretty sure it is breaking something with `mapbox-gl-esri-sources` which we use for the TEMPO data. Before I realized it was just `yarn`, I spent/wasted(?) time tracing down the silent failures causing this. It breaks when the time changes early on - that section is already brittle when it comes to timing.