### PR TITLE
Fix map  updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
     "golden-layout": "^2.6.0",
-    "mapbox-gl-esri-sources": "^0.0.7",
     "maplibre-gl": "^5.5.0",
     "pinia": "^3.0.3",
     "plotly.js-dist-min": "^3.0.3",

--- a/src/composables/useEsriMapLayer.ts
+++ b/src/composables/useEsriMapLayer.ts
@@ -3,7 +3,7 @@ import { RenderingRuleOptions } from '@/esri/ImageLayerConfig';
 import { Map, type MapSourceDataEvent } from 'maplibre-gl';
 import { validate as uuidValidate } from "uuid";
 
-import { ImageService } from 'mapbox-gl-esri-sources';
+import { ImageService } from '@/esri/ImageServiceLayer/ImageService';
 import { TempoDataService } from '@/esri/services/TempoDataService';
 import { type PointBounds } from '@/esri/geometry';
 

--- a/src/esri/ImageServiceLayer/Credit.md
+++ b/src/esri/ImageServiceLayer/Credit.md
@@ -1,0 +1,7 @@
+This is. a local copy of https://github.com/frontiersi/mapbox-gl-esri-sources
+
+We use this in preference to the npm package for better compatabilty with newer version of maplibre-gl. 
+
+The npm package appears to be lacking the check/call to `setTiles` that is supposed to be in v0.0.7 but is not present in the published package.
+
+The original source code was published under the [Apache-2.0](https://choosealicense.com/licenses/apache-2.0/) license

--- a/src/esri/ImageServiceLayer/ImageService.js
+++ b/src/esri/ImageServiceLayer/ImageService.js
@@ -1,0 +1,162 @@
+import {cleanTrailingSlash, getServiceDetails, updateAttribution} from './utils';
+
+export class ImageService {
+
+  constructor (sourceId, map, esriServiceOptions, rasterSrcOptions) {
+    if (!esriServiceOptions.url) throw new Error('A url must be supplied as part of the esriServiceOptions object.');
+
+    esriServiceOptions.url = cleanTrailingSlash(esriServiceOptions.url);
+
+    this._sourceId = sourceId;
+    this._map = map;
+
+    this._defaultEsriOptions = {
+      format: 'jpgpng',
+      dpi: 96,
+      getAttributionFromService: true
+    };
+
+    this.rasterSrcOptions = rasterSrcOptions;
+    this.esriServiceOptions = esriServiceOptions;
+    this._createSource();
+
+    this._serviceMetadata = null;
+
+    if (this.options.getAttributionFromService) this.setAttributionFromService();
+  }
+
+  get options () {
+    return {
+      ...this._defaultEsriOptions,
+      ...this.esriServiceOptions
+    };
+  }
+
+  get _time () {
+    if (!this.options.to) return false;
+    let from = this.options.from;
+    let to = this.options.to;
+    if (from instanceof Date) from = from.valueOf();
+    if (to instanceof Date) to = to.valueOf();
+
+    return `${from},${to}`;
+  }
+
+  get _source () {
+    const tileSize = this.rasterSrcOptions ? this.rasterSrcOptions.tileSize ? this.rasterSrcOptions.tileSize : 256 : 256;
+    // These are the bare minimum parameters
+    const params = new URLSearchParams({
+      bboxSR: 3857,
+      imageSR: 3857,
+      format: this.options.format,
+      size: [tileSize, tileSize],
+      f: 'image'
+    });
+
+    // These are optional params
+    if (this._time) params.append('time', this._time);
+    if (this.options.mosaicRule) params.append('mosaicRule', JSON.stringify(this.options.mosaicRule));
+    if (this.options.renderingRule) params.append('renderingRule', JSON.stringify(this.options.renderingRule));
+
+    return {
+      type: 'raster',
+      tiles: [
+        `${this.options.url}/exportImage?bbox={bbox-epsg-3857}&${params.toString()}`
+      ],
+      tileSize,
+      ...this.rasterSrcOptions
+    };
+  }
+
+  _createSource () {
+    this._map.addSource(this._sourceId, this._source);
+  }
+
+  // This requires hooking into some undocumented methods
+  _updateSource () {
+    const src = this._map.getSource(this._sourceId);
+    src.tiles[0] = this._source.tiles[0];
+    src._options = this._source;
+    if (src.setTiles) {
+      // New MapboxGL >= 2.13.0
+      src.setTiles(this._source.tiles);
+    } else if (this._map.style.sourceCaches) {
+      // Old MapboxGL and MaplibreGL
+      this._map.style.sourceCaches[this._sourceId].clearTiles();
+      this._map.style.sourceCaches[this._sourceId].update(this._map.transform);
+    } else if (this._map.style._otherSourceCaches) {
+      this._map.style.sourceCaches[this._sourceId].clearTiles();
+      this._map.style.sourceCaches[this._sourceId].update(this._map.transform);
+    }
+  }
+
+  setDate (from, to) {
+    this.esriServiceOptions.from = from;
+    this.esriServiceOptions.to = to;
+    this._updateSource();
+  }
+
+  setRenderingRule (rule) {
+    this.esriServiceOptions.renderingRule = rule;
+    this._updateSource();
+  }
+
+  setMosiacRule (rule) {
+    this.esriServiceOptions.mosaicRule = rule;
+    this._updateSource();
+  }
+
+  setAttributionFromService () {
+    if (this._serviceMetadata) updateAttribution(this._serviceMetadata.copyrightText, this._sourceId, this._map);
+    else {
+      this.getMetadata()
+        .then(() => {
+          updateAttribution(this._serviceMetadata.copyrightText, this._sourceId, this._map);
+        });
+    }
+  }
+
+  getMetadata() {
+    if (this._serviceMetadata !== null) return Promise.resolve(this._serviceMetadata);
+    return new Promise((resolve, reject) => {
+      getServiceDetails(this.esriServiceOptions.url, this.esriServiceOptions.fetchOptions)
+        .then((data) => {
+          this._serviceMetadata = data;
+          resolve(this._serviceMetadata);
+        })
+        .catch(err => reject(err));
+    });
+  }
+
+  identify (lnglat, returnGeometry) {
+    const canvas = this._map.getCanvas();
+    const bounds = this._map.getBounds().toArray();
+    returnGeometry = returnGeometry ? returnGeometry : false;
+    const params = new URLSearchParams({
+      sr: 4326,
+      geometryType: 'esriGeometryPoint',
+      geometry: JSON.stringify({
+        x: lnglat.lng,
+        y: lnglat.lat,
+        spatialReference: {
+          wkid: 4326
+        }
+      }),
+      tolerance: 3,
+      returnGeometry,
+      imageDisplay: `${canvas.width},${canvas.height},96`,
+      mapExtent: `${bounds[0][0]},${bounds[0][1]},${bounds[1][0]},${bounds[1][1]}`,
+      layers: this._layersStr,
+      layerDefs: this._layerDefs,
+      time: this._time,
+      f: 'json'
+    });
+
+    return new Promise((resolve, reject) => {
+      fetch(`${this.esriServiceOptions.url}/identify?${params.toString()}`, this.esriServiceOptions.fetchOptions)
+        .then(response => response.json())
+        .then(data => resolve(data))
+        .catch(error => reject(error));
+    });
+  }
+}

--- a/src/esri/ImageServiceLayer/utils.js
+++ b/src/esri/ImageServiceLayer/utils.js
@@ -1,0 +1,38 @@
+export function cleanTrailingSlash (url) {
+  return url.replace(/\/$/, '');
+}
+
+export function getServiceDetails (url, fetchOptions = {}) {
+  return new Promise((resolve, reject) => {
+    fetch(`${url}?f=json`, fetchOptions)
+      .then(response => response.json())
+      .then(data => resolve(data))
+      .catch(error => reject(error));
+  });
+}
+
+const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+// This requires hooking into some undocumented properties
+export function updateAttribution (newAttribution, sourceId, map) {
+  const attributionController = map._controls.find(c => '_attribHTML' in c);
+  if (!attributionController) return;
+
+  const customAttribution = attributionController.options.customAttribution;
+
+  if (typeof customAttribution === 'string') {
+    attributionController.options.customAttribution = `${customAttribution} | ${POWERED_BY_ESRI_ATTRIBUTION_STRING}`;
+  } else if (customAttribution === undefined) {
+    attributionController.options.customAttribution = POWERED_BY_ESRI_ATTRIBUTION_STRING;
+  } else if (Array.isArray(customAttribution)) {
+    if (customAttribution.indexOf(POWERED_BY_ESRI_ATTRIBUTION_STRING) === -1) {
+      customAttribution.push(POWERED_BY_ESRI_ATTRIBUTION_STRING);
+    }
+  }
+
+  if (map.style.sourceCaches) {
+    map.style.sourceCaches[sourceId]._source.attribution = newAttribution;
+  } else if (map.style._otherSourceCaches) {
+    map.style._otherSourceCaches[sourceId]._source.attribution = newAttribution;
+  }
+  attributionController._updateAttributions();
+}

--- a/src/esri/maplibre/useEsriImageLayer.ts
+++ b/src/esri/maplibre/useEsriImageLayer.ts
@@ -3,7 +3,7 @@ import { renderingRule, stretches, colorramps, RenderingRuleOptions, ColorRamps 
 import { type Map, type MapSourceDataEvent } from 'maplibre-gl';
 import { validate as uuidValidate } from "uuid";
 
-import { ImageService } from 'mapbox-gl-esri-sources';
+import { ImageService } from '@/esri/ImageServiceLayer/ImageService';
 import { useEsriTimesteps } from '../../composables/useEsriTimesteps';
 import { MoleculeType } from '../utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,7 +250,6 @@ __metadata:
     golden-layout: "npm:^2.6.0"
     less: "npm:^4.2.0"
     less-loader: "npm:^12.0.0"
-    mapbox-gl-esri-sources: "npm:^0.0.7"
     maplibre-gl: "npm:^5.5.0"
     pinia: "npm:^3.0.3"
     plotly.js-dist-min: "npm:^3.0.3"
@@ -5606,13 +5605,6 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^13.0.0"
   checksum: 10/78da4fc1df83cb596e2bae25aa0653b8a9c6cbdd6674a104894e03be3acfcd08c70b78f06ef6407fbd6b173f6a60672480d78641e693d05eb71c09c13ee35278
-  languageName: node
-  linkType: hard
-
-"mapbox-gl-esri-sources@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "mapbox-gl-esri-sources@npm:0.0.7"
-  checksum: 10/528c20bc86a7aa7183f01339fe61a693950832eb9aba63be0cfe11f0cdb43da6b02f2aa8ffc3c9362b5d5d0617db39e47580a8113431ec1594d710876ad89cae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updaets the repo to use a local version of `mapbox-gl-esri-sources`. This package depended on non-public api's which have been changed. It appears the maintainer updated the package to fix this, but the npm package does not reflect these changes (in particular, a crucial `setTiles` call).

This PR punts on 
- investigating why it sometimes worked and sometimes didn't (such as, this only breaks for me, after someone mentions it). Maybe something to do with the order in which packagers were getting resolved?
- We currently load timestamps from the local cache and from the ImageService. This is probably fine, since the store is loaded before we pull the new ones, but this doesn't seem to cause a problme
- Currenlty we get timestamps from the EsriMap layer. Once we start using v4 data, we will need to rethink this, and probably stop using the EsriMap component (which should also be fine)