### PR TITLE
Respect RGB mode flag when initializing layers

### DIFF
--- a/src/components/EsriMap.vue
+++ b/src/components/EsriMap.vue
@@ -42,6 +42,7 @@
 <script setup lang="ts">
 import { ref, watch, toRef, computed, type Ref, useTemplateRef, onMounted } from 'vue';
 import type { PropType } from 'vue';
+import { storeToRefs } from "pinia";
 import type { Map } from 'maplibre-gl';
 import MaplibreMap from './MaplibreMap.vue';
 import { useTempoLayer } from '@/esri/maplibre/useTempoImageLayer';
@@ -54,6 +55,8 @@ import type { AvailableColorMaps } from "@/colormaps";
 import { useTempoStore } from "@/stores/app";
 
 const store = useTempoStore();
+
+const { showRGBMode } = storeToRefs(store);
 
 const props = defineProps({
   mapID: { type: String, required: true },
@@ -160,13 +163,15 @@ const timestampRef = toRef(props, 'timestamp');
 const opacityRef = toRef(props, 'opacity');
 
 // ESRI layer composable
-const theEsriLayer = useTempoLayer(
-  molecule,
-  timestampRef,
-  opacityRef,
-  true,
-  props.maplibreLayerName
-);
+const theEsriLayer = useTempoLayer({
+  initialMolecule: molecule,
+  timestamp: timestampRef,
+  opacity: opacityRef,
+  fetchOnMount: true,
+  layerName: props.maplibreLayerName,
+  initVisible: true,
+  initRGB: showRGBMode.value,
+});
 
 const { loadingEsriTimeSteps, addEsriSource, esriTimesteps, renderOptions } = theEsriLayer;
 

--- a/src/components/MapWithControls.vue
+++ b/src/components/MapWithControls.vue
@@ -256,8 +256,24 @@ const hmsFire = addHMSFire(singleDateSelected, {
 
 import { type UseEsriTempoLayer, useTempoLayer } from "@/esri/maplibre/useTempoImageLayer";
 // just use the hcho layer for now
-const hchoLayer = useTempoLayer('hcho', timestamp, 1, true, 'tempo-hcho', false);
-const ozoneLayer = useTempoLayer('o3', timestamp, 1, true, 'tempo-o3', false);
+const hchoLayer = useTempoLayer({
+  initialMolecule: "hcho",
+  timestamp,
+  opacity: 1,
+  fetchOnMount: true,
+  layerName: "tempo-hcho",
+  initVisible: false,
+  initRGB: showRGBMode.value,
+});
+const ozoneLayer = useTempoLayer({
+  initialMolecule: "o3",
+  timestamp,
+  opacity: 1,
+  fetchOnMount: true,
+  layerName: "tempo-o3",
+  initVisible: false,
+  initRGB: showRGBMode.value,
+});
 const no2Layer = ref<UseEsriTempoLayer | null>(null);
 
 function addAdvancedLayers(m: Map | null) {


### PR DESCRIPTION
This PR resolves #161. Along the way I combined the `useEsriLayer` arguments into one options object, as the function signature was beginning to get a bit unwieldy.