### PR TITLE
Convert v-model bindings for functions to regular props

### DIFF
--- a/src/components/DataFoldingAndBinning.vue
+++ b/src/components/DataFoldingAndBinning.vue
@@ -15,10 +15,10 @@
               >
               <AggregationControls
                 :foldingPeriodOptions="foldingPeriodOptions"
-                v-model:validFoldingForData="validFoldingForData"
+                :validFoldingForData="validFoldingForData"
                 :timeBinOptions="timeBinOptions"
-                v-model:validTimeBinForData="validTimeBinForData"
-                v-model:isValidCombination="isValidCombination"
+                :validTimeBinForData="validTimeBinForData"
+                :isValidCombination="isValidCombination"
                 v-model:useTzCenter="useTzCenter"
                 v-model:tzCenter="tzCenter"
                 v-model:selectedTimezone="selectedTimezone"


### PR DESCRIPTION
I was having an issue opening the aggregation controls because we're currently passing in some functions as `v-model` props. This PR converts these to just be regular props.