### PR TITLE
Download canvas image

### DIFF
--- a/src/components/MapWithControls.vue
+++ b/src/components/MapWithControls.vue
@@ -6,6 +6,15 @@
         color="var(--info-background)"
       >
         <v-toolbar-title text="TEMPO Data Viewer"></v-toolbar-title>
+        <v-tooltip text="Save map as image">
+          <template #activator="{ props }">
+            <MaplibreDownloadButton
+              v-bind="props"
+              :map="map" 
+              filename="tempo-lab"
+              />
+          </template>
+        </v-tooltip>
         <!-- switch for preview points -->
         <v-tooltip :text="selectionActive === 'rectangle' ? 'Cancel selection' : 'Select a region'">
           <template #activator="{ props }">
@@ -143,6 +152,7 @@ import { setLayerOpacity, setLayerVisibility } from "@/maplibre_controls";
 
 import EsriMap from "@/components/EsriMap.vue";
 import MapColorbarWrap from "@/components/MapColorbarWrap.vue";
+import MaplibreDownloadButton from "@/components/MaplibreDownloadButton.vue";
 
 type MapType = Map | null;
 type MapTypeRef = Ref<MapType>;
@@ -698,24 +708,6 @@ watch(focusRegion, region => {
   }
 });
 
-
-
-import { downloadCanvasToImage } from "@/utils/canvas_downloader";
-import { AllAvailableColorMaps } from "@/colormaps";
-function downloadMap() {
-  if (!map.value) {
-    alert('Map not ready yet!');
-    return;
-  }
-  const html = map.value.getCanvas();
-  console.log('Downloading map image...', html);
-  // see: https://stackoverflow.com/a/78283389/11594175
-  map.value.once('render', () => {
-    downloadCanvasToImage(html, 'tempo-map.png');
-  });
-  map.value.redraw();
-  
-}
 </script>
 
 <style lang="less">

--- a/src/components/MaplibreDownloadButton.vue
+++ b/src/components/MaplibreDownloadButton.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-btn
+  @click="onClick"
+  @keyup.enter="onClick"
+  icon="mdi-camera-outline"
+  >
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { downloadMap } from '@/utils/canvas_downloader';
+import { type Map } from 'maplibre-gl';
+
+interface MaplibreDownloadButtonProps {
+  map: Map,
+  filename: string
+}
+
+const props = defineProps<MaplibreDownloadButtonProps>();
+
+const onClick = () => {
+  downloadMap(props.map, props.filename);
+};
+</script>

--- a/src/components/UserDatasetTable.vue
+++ b/src/components/UserDatasetTable.vue
@@ -27,7 +27,7 @@
 import { computed } from 'vue';
 import type { Prettify, UserDataset, UnifiedRegion } from '@/types';
 import type { FoldedTimeSeriesData, } from '@/esri/services/aggregation';
-import type { TimeBinOptions, FoldingPeriodOptions } from './DataFoldingAndBinning.vue';
+import type { TimeBinOptions, FoldingPeriodOptions } from '@/utils/foldingValidation';
 
 
 import tz_lookup from '@photostructure/tz-lookup';

--- a/src/utils/canvas_downloader.ts
+++ b/src/utils/canvas_downloader.ts
@@ -1,13 +1,35 @@
+import { Map } from 'maplibre-gl';
 /** 
  * Utitlity function for downloading canvas content as an image file.
  */
-export function downloadCanvasToImage(canvas: HTMLCanvasElement, filename: string = 'canvas_image.png') {
+type ImageFormats = 'png' | 'jpeg';
+export function downloadCanvasToImage(canvas: HTMLCanvasElement, filename: string = 'canvas_image', format: ImageFormats = 'png') {
   console.log('Downloading canvas to image...');
-  const dataUrl = canvas.toDataURL('image/png');
+  const dataUrl = canvas.toDataURL(`image/${format}`);
   const link = document.createElement('a');
   link.href = dataUrl;
   link.download = filename;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+}
+
+export function downloadMap(map: Map, name = 'tempo-map', format: ImageFormats = 'png') {
+  if (!map) {
+    alert('Map not ready yet!');
+    return;
+  }
+  
+  // use regex so that if name ends with .png, .jpeg, .jpg, strip it off
+  name = name.replace(/\.(png|jpeg|jpg)$/i, '');
+  
+  const html = map.getCanvas();
+  console.log('Downloading map image...', html);
+  // see: https://stackoverflow.com/a/78283389/11594175
+  map.once('render', () => {
+    // do this once when we render
+    downloadCanvasToImage(html, name, format);
+  });
+  map.redraw(); // render now!
+  
 }


### PR DESCRIPTION
This PR adds in the long over-due ability to download the current view as an image. It currently does this with a button in the toolbar, but this can be moved anywhere we want.
