### PR TITLE
Fix some minor issues when recovering from a downed service

### DIFF
--- a/src/components/EsriMap.vue
+++ b/src/components/EsriMap.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, toRef, computed, type Ref, useTemplateRef, onMounted } from 'vue';
+import { ref, watch, toRef, computed, type Ref, useTemplateRef, onMounted, shallowRef } from 'vue';
 import type { PropType } from 'vue';
 import { storeToRefs } from "pinia";
 import type { Map } from 'maplibre-gl';
@@ -138,7 +138,7 @@ const emit = defineEmits<{
 
 // Reference to inner MaplibreMap exposed API
 const innerMap = useTemplateRef<InstanceType<typeof MaplibreMap> | null>("innerMap");
-const map = ref<Map | null>(null);
+const map = shallowRef<Map | null>(null);
 
 // Pass-through models for view state
 const latitude = defineModel<number>('latitude', { default: 0 });

--- a/src/components/LayerOrderControl.vue
+++ b/src/components/LayerOrderControl.vue
@@ -132,7 +132,7 @@ const displayOrder = computed({
   get(): string[] {
     const reversed = currentOrder.value.slice().reverse();
     // Push not ready layers to the bottom, still in order though
-    const ready = reversed.filter(isLayerReady);
+    const ready = reversed.filter(isLayerReady as () => boolean);
     const notReady = reversed.filter(id => !isLayerReady(id));
     return [...ready, ...notReady];
   },
@@ -216,6 +216,14 @@ const customServiceWarning = {
   'land': "ESRI's service for this layer is down. See https://livingatlas.arcgis.com/landcoverexplorer/ for more information.",
 };
 
+const _partialServiceWarning = "The service supporting this layer is down, all or some data may be unavailable.";
+// create custom warning for pop-dense, land-use, tempo data. still short but blames the provider
+const partialCustomServiceWarning = {
+  'tempo': "Due to a disruption of NASA's Earthdata GIS service some data may be unavailable. ",
+  'pop': "Due to a disruption of NASA's Earthdata GIS service some data may be unavailable. ",
+  'land': "Due to a disruption ESRI's service for this layer is down. See https://livingatlas.arcgis.com/landcoverexplorer/ for more information.",
+};
+
 function displayNameTransform(layerId: string): string {
   return layerNames[layerId] ?? capitalizeWords(layerId.replace(/-/g, " "));
 }
@@ -235,29 +243,43 @@ watch(layersReady, () => {
   }
 }, { deep: true });
 
-function isLayerReady(layerId: string): boolean {
+// use function overrirde to enforce what can be returned
+function isLayerReady(layerId: string, includePartial: true): true | {ready: boolean, partial: boolean};
+// eslint-disable-next-line no-redeclare
+function isLayerReady(layerId: string, includePartial: false): boolean;
+// eslint-disable-next-line no-redeclare
+function isLayerReady(layerId: string, includePartial = false) {
   const readiness = layersReady.value.get(layerId);
   if (!readiness || readiness.length === 0) {
     return true; // was null, no warning message, so true
+  }
+  if (includePartial) {
+    return {
+      ready: readiness.every(ready => ready),
+      partial: readiness.some(ready => ready) && !readiness.every(ready => ready)
+    };
   }
   return readiness.every(ready => ready); // actually have to check
 }
 
 
 function warningMessage(layerId: string): string | null {
-
-  if (isLayerReady(layerId)) {
+  const ready = isLayerReady(layerId, true);
+  console.log('LAYER CONTROL', layerId, ready);
+  // if ready is truthy, no error message
+  if (ready === true || ready.ready === true) {
     return null;
   }
+
   // return serviceWarning;
   if (layerId.startsWith('tempo')) {
-    return customServiceWarning['tempo'];
+    return ready.partial ? partialCustomServiceWarning['tempo'] : customServiceWarning['tempo'];
   } else if (layerId.startsWith('pop')) {
-    return customServiceWarning['pop'];
+    return ready.partial ? partialCustomServiceWarning['pop'] : customServiceWarning['pop'];
   } else if (layerId.startsWith('land')) {
-    return customServiceWarning['land'];
+    return ready.partial ? partialCustomServiceWarning['land'] : customServiceWarning['land'];
   } else {
-    return serviceWarning;
+    return ready.partial ? _partialServiceWarning : serviceWarning;
   }
 }
 

--- a/src/components/MapWithControls.vue
+++ b/src/components/MapWithControls.vue
@@ -103,7 +103,7 @@
 
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { computed, ref, toRaw, useTemplateRef, watch, type Ref, type WritableComputedRef } from "vue";
+import { computed, ref, shallowRef, toRaw, useTemplateRef, watch, type Ref, type WritableComputedRef } from "vue";
 import { useDisplay } from 'vuetify';
 import { storeToRefs } from "pinia";
 import { MapBoxFeature, MapBoxFeatureCollection, MapBoxFeatureType, MapBoxForwardGeocodingOptions, geocodingInfoForSearch } from "@cosmicds/vue-toolkit";
@@ -132,7 +132,7 @@ import MaplibreDownloadButton from "@/components/MaplibreDownloadButton.vue";
 type MapType = Map | null;
 type MapTypeRef = Ref<MapType>;
 const maplibreMap = useTemplateRef<InstanceType<typeof EsriMap>>("maplibreMap");
-const map = ref<MapType>(null);
+const map = shallowRef<MapType>(null);
 
 type Timeout = ReturnType<typeof setTimeout>;
 
@@ -305,7 +305,7 @@ function removeAdvancedLayers(m: Map | null) {
   if (m === null) {
     throw new Error('Tried to removeAdvancedLayers but map was null');
   }
-  tempoLite.removeFromMap();
+  // tempoLite.removeFromMap();
   aqiLayer.removeFromMap(m);
   popLayer.removeEsriSource();
   sentinalLandUseLayer.removeEsriSource();
@@ -321,6 +321,7 @@ function removeAdvancedLayers(m: Map | null) {
 
 const onMapReady = (m: Map) => {
   map.value = m; // ESRI source already added by EsriMap
+  syncLayerReady('tempo-no2', no2Layer.value?.serviceReady); // needs to be done early
   tempoLite.addTo(m);
   tempoLite.setVisibility(false);
   if (showAdvancedLayers.value) addAdvancedLayers(m);
@@ -330,10 +331,10 @@ const onMapReady = (m: Map) => {
 
 watch(showAdvancedLayers, (value) => {
   if (value) {
-    addAdvancedLayers(map.value as Map | null);
+    addAdvancedLayers(map.value);
     return;
   }
-  removeAdvancedLayers(map.value as Map | null);
+  removeAdvancedLayers(map.value);
   
   
 });
@@ -592,8 +593,8 @@ function addLayer(
 ): { layer: GeoJSONSource } {
   const isRect = geometryType === 'rectangle';
   const layerInfo = isRect ?
-    addRectangleLayer((map.value as MapType)!, info as RectangleSelectionInfo, color, regionOpacity.value, regionVisibility.value) :
-    addPointLayer((map.value as MapType)!, info as PointSelectionInfo, color, regionVisibility.value);
+    addRectangleLayer((map.value)!, info as RectangleSelectionInfo, color, regionOpacity.value, regionVisibility.value) :
+    addPointLayer((map.value)!, info as PointSelectionInfo, color, regionVisibility.value);
   map.value?.moveLayer(layerInfo.layer.id);
   return layerInfo;
 }
@@ -604,9 +605,9 @@ function removeLayer(
 ) {
   const isRect = geometryType === 'rectangle';
   if (isRect) {
-    removeRectangleLayer((map.value as MapType)!, layer);
+    removeRectangleLayer((map.value)!, layer);
   } else {
-    removePointLayer((map.value as MapType)!, layer);
+    removePointLayer((map.value)!, layer);
   }
 }
 
@@ -658,18 +659,18 @@ watch(regions, updateRegionLayers, { deep: true });
 watch(regionOpacity, (opacity: number) => {
   if (map.value !== null) {
     Object.values(regionLayers).forEach(layer => {
-      setLayerOpacity(map.value as Map, layer.id, opacity);
+      setLayerOpacity(map.value!, layer.id, opacity);
     });
-    setLayerOpacity(map.value as Map, "predicted-samples-locations-layer", opacity);
+    setLayerOpacity(map.value, "predicted-samples-locations-layer", opacity);
   }
 });
 
 watch(regionVisibility, (visible: boolean) => {
   if (map.value !== null) {
     Object.values(regionLayers).forEach(layer => {
-      setLayerVisibility(map.value as Map, layer.id, visible);
+      setLayerVisibility(map.value!, layer.id, visible);
     });
-    setLayerVisibility(map.value as Map, "predicted-samples-locations-layer", visible);
+    setLayerVisibility(map.value, "predicted-samples-locations-layer", visible);
   }
 });
 

--- a/src/components/MaplibreLayerControlItem.vue
+++ b/src/components/MaplibreLayerControlItem.vue
@@ -14,6 +14,7 @@
         hide-details
         color="primary"
         :label="displayName ?? layerId"
+        :disabled="disabled"
       >
         <template #label>
           {{ displayName ?? layerId }}
@@ -73,6 +74,7 @@ interface Props {
   map: Map;
   displayName?: string;
   syncedItems?: string[];
+  disabled?: boolean;
 }
 
 const props = defineProps<Props>();

--- a/src/composables/addHMSFire.ts
+++ b/src/composables/addHMSFire.ts
@@ -289,7 +289,9 @@ export function addHMSFire(date: Ref<Date>, options: UseKMLOptions = {layerName:
       await loadKML();
     }
     if (!geoJsonData.value) {
-      throw new Error('No GeoJSON data available');
+      console.error('[hms-fire] No GeoJSON data available');
+      cleanupMapLayers();
+      return;
     }
 
     // Remove existing layer and source if they exist

--- a/src/composables/maplibre/useMap.ts
+++ b/src/composables/maplibre/useMap.ts
@@ -1,5 +1,5 @@
-import { Ref, ref, onMounted, onUnmounted } from 'vue';
-import M, { Map, AttributionControl } from 'maplibre-gl';
+import { Ref, onMounted, onUnmounted, shallowRef } from 'vue';
+import M, { AttributionControl } from 'maplibre-gl';
 import { InitMapOptions, LatLngPair } from '@/types';
 
 
@@ -21,7 +21,7 @@ export function useMap(id="map", options: InitMapOptions, _showRoads: Ref<boolea
   // Something to know about MatLibre it likes longitude, latitude as opposed
   // to leaflet which uses latitude, longitude
   // this is where our map will be
-  const map = ref<M.Map | null>(null);
+  const map = shallowRef<M.Map | null>(null);
   
   async function addStates(map: M.Map) {
     fetch("states.geojson")
@@ -111,7 +111,7 @@ export function useMap(id="map", options: InitMapOptions, _showRoads: Ref<boolea
     // Need to use weird type assertion to avoid
     // Type instantiation is excessively deep and possibly infinite.ts(2589)
     // See discussion here https://github.com/mapbox/mapbox-gl-js/issues/13203#issuecomment-2634013147
-    const libreMap = map.value as unknown as M.Map;
+    const libreMap = map.value;
     
 
     // libreMap.setProjection({

--- a/src/composables/useEsriMapLayer.ts
+++ b/src/composables/useEsriMapLayer.ts
@@ -1,4 +1,4 @@
-import { ref, watch, Ref, MaybeRef, toRef, computed } from 'vue';
+import { ref, shallowRef, watch, Ref, MaybeRef, toRef, computed } from 'vue';
 import { RenderingRuleOptions } from '@/esri/ImageLayerConfig';
 import { Map, type MapSourceDataEvent } from 'maplibre-gl';
 import { validate as uuidValidate } from "uuid";
@@ -43,7 +43,7 @@ export function useEsriImageServiceLayer(
   const url = ref(serviceUrl);
   const esriLayerId = layerId;
   const esriImageSource = ref<maplibregl.RasterTileSource | null>(null);
-  const map = ref<Map | null>(null);
+  const map = shallowRef<Map | null>(null);
   const variableRef = toRef(variable);
   
   const tds = new TempoDataService(serviceUrl, variableRef.value);
@@ -119,7 +119,9 @@ export function useEsriImageServiceLayer(
       console.log(`ESRI source ${esriLayerId} loaded`);
       esriImageSource.value = map.value?.getSource(esriLayerId) as maplibregl.RasterTileSource;
       updateEsriOpacity();
-      dynamicMapService.value.setDate(new Date(timestamp.value-1), new Date(timestamp.value+1));
+      if (dynamicMapService.value) {
+        dynamicMapService.value.setDate(new Date(timestamp.value - 1), new Date(timestamp.value + 1));
+      }
       if (options.visible !== undefined && !options.visible) {
         map.value?.setLayoutProperty(esriLayerId, 'visibility', 'none');
       }
@@ -184,7 +186,7 @@ export function useEsriImageServiceLayer(
   
   watch(timestamp, (_value) => {
     console.log(`[${esriLayerId}] esri imageset timestamp set to `, _value ? new Date(_value) : null);
-    if ( _hasEsriSource() ) {
+    if ( _hasEsriSource() && dynamicMapService.value) {
       dynamicMapService.value.setDate(new Date(_value-1), new Date(_value+1));
     } else {
       console.error(`[${esriLayerId}] ESRI source not yet available`);

--- a/src/composables/useMaplibreLayerOrderControl.ts
+++ b/src/composables/useMaplibreLayerOrderControl.ts
@@ -103,15 +103,12 @@ export class MaplibreLayerOrderControl extends PsuedoEvent {
     if (options.linkedLayers) {
       this._linked = options.linkedLayers.map(link => this._newLink(link));
     }
-    
-    const idleListener = () => {
-      this._orderLayers();
-      this._initialized = true;
-      this._watchForChanges();
-      this._map.off('idle', idleListener);
-    };
-    // wait for map to be ready
-    this._map.on('idle',idleListener);
+
+    // we can add lifecycle listeners immediately
+    // waiting for idle was causing it to miss early changes
+    this._watchForChanges();
+    this._orderLayers();
+    this._initialized = true;
     
   }
   
@@ -309,8 +306,11 @@ export class MaplibreLayerOrderControl extends PsuedoEvent {
   
   private _watchForChanges() {
     const onStyleData = () => this._maintainOrder();
+    const onIdle = () => this._maintainOrder();
     this._map.on('styledata', onStyleData);
+    this._map.on('idle', onIdle);
     this._eventHandlers.push(['styledata', onStyleData]);
+    this._eventHandlers.push(['idle', onIdle]);
   }
   
   /**
@@ -599,20 +599,29 @@ export function useMaplibreLayerOrderControl(
   let controller: MaplibreLayerOrderControl | null = null;
   let initialized = false;
   
+  function syncCurrentOrder() {
+    if (controller && !checkArrayEquality(currentOrder.value, controller.currentlyManagedLayerOrder ?? [])) {
+      currentOrder.value = controller?.currentlyManagedLayerOrder ?? [];
+    }
+  }
+  
   // Initialize the controller when the map is ready
-  function init(mapValue: M.Map | null) {
+  function init(mapValue: M.Map) {
     if (mapValue && !controller && !initialized) {
       controller = new MaplibreLayerOrderControl(mapValue, desiredOrder.value, {keepAtTop: moveToTop, linkedLayers: linkedLayers});
       controller.on('layer-order-changed', () => {
-        if (controller && !checkArrayEquality(currentOrder.value, controller.currentlyManagedLayerOrder ?? [])) {
-          currentOrder.value = controller?.currentlyManagedLayerOrder ?? [];
-        }
+        syncCurrentOrder();
       });
-      currentOrder.value = controller.currentlyManagedLayerOrder;
+      // currentOrder.value = controller.currentlyManagedLayerOrder;
+      syncCurrentOrder();
       initialized = true;
     }
   }
-  init(map.value);
+  
+  if (map.value) {
+    init(map.value);
+  }
+  
   watch(map, (newValue) => {
     if (newValue && !controller && !initialized) {
       console.log('Map changed, re-initializing controller', newValue);
@@ -637,6 +646,7 @@ export function useMaplibreLayerOrderControl(
   
   onBeforeUnmount(() => {
     controller?.destroy();
+    controller = null;
   });
   
   

--- a/src/esri/ImageServiceLayer/ImageService.d.ts
+++ b/src/esri/ImageServiceLayer/ImageService.d.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import M from "maplibre-gl";
+
+
+export declare class ImageService {
+  constructor(sourceId: string, map: M.Map, esriServiceOptions: object, rasterSrcOptions: object);
+  get options(): any;
+  get _time(): string | false;
+  get _source(): any;
+  _createSource(): void;
+  _updateSource(): void;
+  setDate(from: Date, to: Date): void;
+  setRenderingRule(rule: object): void;
+  setMosiacRule(rule: object): void;
+  setAttributionFromService(): void;
+  getMetadata(): Promise<any>;
+  identify(lnglat: any, returnGeometry: any): Promise<unknown>;
+  esriServiceOptions: any;
+  rasterSrcOptions: any;
+  _map: M.Map;
+}

--- a/src/esri/ImageServiceLayer/ImageService.js
+++ b/src/esri/ImageServiceLayer/ImageService.js
@@ -22,7 +22,13 @@ export class ImageService {
 
     this._serviceMetadata = null;
 
-    if (this.options.getAttributionFromService) this.setAttributionFromService();
+    try {
+      if (this.options.getAttributionFromService) this.setAttributionFromService();
+    } catch (error) {
+      // this can fail if we have flakiness in the service
+      // but it is not a critical failure, so just catch & log
+      console.error(error);
+    }
   }
 
   get options () {
@@ -107,25 +113,32 @@ export class ImageService {
   }
 
   setAttributionFromService () {
-    if (this._serviceMetadata) updateAttribution(this._serviceMetadata.copyrightText, this._sourceId, this._map);
-    else {
-      this.getMetadata()
-        .then(() => {
-          updateAttribution(this._serviceMetadata.copyrightText, this._sourceId, this._map);
+    // check for the copyright text. the service 
+    // may not actually have copyrightText as a key
+    if (this._serviceMetadata?.copyrightText) {
+      updateAttribution(this._serviceMetadata.copyrightText, this._sourceId, this._map);
+    } else {
+      this.getMetadata() // just get the fresh metadata from the promise instead of hoping it it synced internally
+        .then((metadata) => {
+          if (metadata?.copyrightText) {
+            updateAttribution(metadata.copyrightText, this._sourceId, this._map);
+          }
         });
     }
   }
-
+  
+  // update to better handle esri's error (it returns valid json, but not what you expect)
   getMetadata() {
     if (this._serviceMetadata !== null) return Promise.resolve(this._serviceMetadata);
-    return new Promise((resolve, reject) => {
-      getServiceDetails(this.esriServiceOptions.url, this.esriServiceOptions.fetchOptions)
-        .then((data) => {
-          this._serviceMetadata = data;
-          resolve(this._serviceMetadata);
-        })
-        .catch(err => reject(err));
-    });
+    // getServiceDetails is now a Promise, we can return it directly
+    return getServiceDetails(this.esriServiceOptions.url, this.esriServiceOptions.fetchOptions)
+      .then((data) => {
+        if (!data) {
+          throw new Error(`Service metadata was falsy: ${data}`);
+        }
+        this._serviceMetadata = data;
+        return this._serviceMetadata;
+      });
   }
 
   identify (lnglat, returnGeometry) {

--- a/src/esri/maplibre/useTempoImageLayer.ts
+++ b/src/esri/maplibre/useTempoImageLayer.ts
@@ -1,4 +1,4 @@
-import { ref, watch, Ref, MaybeRef, toRef, nextTick, computed } from 'vue';
+import { ref, watch, Ref, MaybeRef, toRef, nextTick, computed, shallowRef } from 'vue';
 import { renderingRule, stretches, colorramps, rgbcolorramps, RenderingRuleOptions, ColorRamps } from '../ImageLayerConfig';
 import { type Map, type MapSourceDataEvent } from 'maplibre-gl';
 import { validate as uuidValidate } from "uuid";
@@ -38,7 +38,7 @@ export function useTempoLayer(esriLayerOptions: UseEsriTempoLayerOptions): UseEs
 
   const esriLayerId = esriLayerOptions.layerName ?? 'esri-source';
   const esriImageSource = ref<maplibregl.RasterTileSource | null>(null);
-  const map = ref<Map | null>(null);
+  const map = shallowRef<Map | null>(null);
   const molecule = toRef(esriLayerOptions.initialMolecule);
   const store = useTempoStore();
 
@@ -293,9 +293,9 @@ export function useTempoLayer(esriLayerOptions: UseEsriTempoLayerOptions): UseEs
   watch(noEsriData, (value: boolean) => {
     if (value) {
       updateEsriOpacity(0);
-      removeLayer(map.value as Map | null);
+      removeLayer(map.value);
     } else {
-      addLayer(map.value as Map | null);
+      addLayer(map.value);
     }
   });
 

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -529,6 +529,9 @@ export function postDeserializeTempoStore(store: TempoStore) {
 export function updateStoreFromJSON(store: TempoStore, json: string): boolean {
   try {
     const state = deserializeTempoStore(json);
+    if (store.timestampsLoaded) {
+      delete state.timestamps;
+    }
     store.$patch(state);
     postDeserializeTempoStore(store);
     return true;


### PR DESCRIPTION
The most important change is not loading timestamps if they have already been loaded from the service. This makes sure we are not ovewriting anything after we have gotten authoritative timestamps from the service. We also show an error on partial failures, so the user has some indication something is wrong. 

A couple performance improvements
- use `shallowRef` for `map` instances. deep reactivity on this is not needed
- make the layer control more responsive on initialization